### PR TITLE
Auto-build on PR or Check-In

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,6 @@ jobs:
           econet_heatpump_water_heater.yaml  \
           econet_hvac.yaml \
           econet_tankless_water_heater.yaml
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+---
+name: Build Firmware
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build Firmware
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+
+      - name: Install ESPHome
+        run: pip install --user esphome
+
+      - name: Compile Release Firmware
+        run: |
+          esphome compile \
+          econet_heatpump_water_heater.yaml  \
+          econet_hvac.yaml \
+          econet_tankless_water_heater.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,4 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,24 +10,18 @@ on:
 jobs:
   build:
     name: Build Firmware
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v4
-
       - name: Install ESPHome
         run: pip install --user esphome
-
       - name: Compile Release Firmware
         run: |
           esphome compile \
           econet_heatpump_water_heater.yaml  \
           econet_hvac.yaml \
           econet_tankless_water_heater.yaml
-
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,3 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.0
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true


### PR DESCRIPTION
I more or less copied this workflow from another esphome component. It will kick off a build with the latest esphome on each check-in; it should help us ensure that code at least compiles and monitor that new esphome releases don't break us.

I hope next to enable dependabot to kick off a PR on every esphome release which will then trigger this workflow.