### PR TITLE
Trying dependabot to auto-check new esphome upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
-      - name: Install ESPHome
-        run: pip install --user esphome
+      - name: Install Dependencies
+        run: pip install --user -r ./requirements.txt
       - name: Compile Release Firmware
         run: |
           esphome compile \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome>=2023.2.0
-pre-commit>=3.4.0
+esphome==2023.8.3
+pre-commit==3.4.0


### PR DESCRIPTION
Tested this on my side and it works great. If the `esphome` version in `requirements.txt` is behind the latest release, dependabot will cut a PR which in turn will trigger a compile check. This will also work for `pre-commit` releases.