### PR TITLE
Move common configuration to econet_base.yaml to reduce duplication

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -1,0 +1,65 @@
+---
+substitutions:
+  name: "econet"
+  friendly_name: "Econet Device"
+  device_description: "Rheem Device"
+  tx_pin: GPIO19
+  rx_pin: GPIO22
+  platform: esp32
+  board: esp32dev
+  external_components_source: github://esphome-econet/esphome-econet@main
+  logger_level: WARN
+  econet_update_interval: 30s
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  comment: ${device_description}
+  min_version: "2023.2.0"
+  platform: $platform
+  board: $board
+  project:
+    name: "esphome-econet.esphome-econet"
+    version: 0.3.1
+
+preferences:
+  flash_write_interval: "24h"
+
+wifi:
+  ap:
+
+captive_portal:
+
+api:
+
+ota:
+
+logger:
+  baud_rate: 0  # Make sure logging is not using the serial port
+  level: ${logger_level}
+  tx_buffer_size: 2000
+
+external_components:
+  - source: ${external_components_source}
+
+uart:
+  id: uart_0
+  baud_rate: 38400
+  rx_buffer_size: 1500
+  tx_pin: ${tx_pin}
+  rx_pin: ${rx_pin}
+
+econet:
+  uart_id: uart_0
+  update_interval: ${econet_update_interval}
+
+binary_sensor:
+  - platform: econet
+    name: "Active Alerts"
+    sensor_datapoint: ALRMALRT
+    device_class: "problem"
+
+sensor:
+  - platform: wifi_signal
+    name: "WiFi Signal Strength"
+    entity_category: "diagnostic"

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -20,7 +20,7 @@ esphome:
   board: $board
   project:
     name: "esphome-econet.esphome-econet"
-    version: 0.3.1
+    version: 0.3.0
 
 preferences:
   flash_write_interval: "24h"
@@ -52,12 +52,6 @@ uart:
 econet:
   uart_id: uart_0
   update_interval: ${econet_update_interval}
-
-binary_sensor:
-  - platform: econet
-    name: "Active Alerts"
-    sensor_datapoint: ALRMALRT
-    device_class: "problem"
 
 sensor:
   - platform: wifi_signal

--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -3,61 +3,17 @@ substitutions:
   name: "econet-etwh"
   friendly_name: "Water Heater"
   device_description: "Rheem Electric Tank Water Heater"
-  tx_pin: GPIO19
-  rx_pin: GPIO22
-  platform: esp32
-  board: esp32dev
-  external_components_source: github://esphome-econet/esphome-econet@main
-  logger_level: WARN
-  econet_update_interval: 30s
   sensor_power_filters_lambda: return x;
 
-esphome:
-  name: ${name}
-  friendly_name: ${friendly_name}
-  comment: ${device_description}
-  min_version: "2023.2.0"
-  platform: $platform
-  board: $board
-  project:
-    name: "esphome-econet.esphome-econet"
-    version: 0.3.0
+packages:
+  econet: !include econet_base.yaml
 
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/econet_electric_tank_water_heater.yaml@main
   import_full_config: false
 
-preferences:
-  flash_write_interval: "24h"
-
-wifi:
-  ap:
-
-captive_portal:
-
-api:
-
-ota:
-
-logger:
-  baud_rate: 0  # Make sure logging is not using the serial port
-  level: ${logger_level}
-  tx_buffer_size: 2000
-
-external_components:
-  - source: ${external_components_source}
-
-uart:
-  id: uart_0
-  baud_rate: 38400
-  rx_buffer_size: 1500
-  tx_pin: ${tx_pin}
-  rx_pin: ${rx_pin}
-
 econet:
-  uart_id: uart_0
   model: "Electric Tank"
-  update_interval: ${econet_update_interval}
 
 climate:
   - platform: econet
@@ -101,9 +57,6 @@ sensor:
     entity_category: "diagnostic"
     filters:
       - lambda: ${sensor_power_filters_lambda}
-  - platform: wifi_signal
-    name: "WiFi Signal Strength"
-    entity_category: "diagnostic"
 
 text_sensor:
   - platform: econet

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -3,61 +3,17 @@ substitutions:
   name: "econet-hpwh"
   friendly_name: "Water Heater"
   device_description: "Rheem Heat Pump Water Heater"
-  tx_pin: GPIO19
-  rx_pin: GPIO22
-  platform: esp32
-  board: esp32dev
-  external_components_source: github://esphome-econet/esphome-econet@main
-  logger_level: WARN
-  econet_update_interval: 30s
   sensor_power_filters_lambda: return x;
 
-esphome:
-  name: ${name}
-  friendly_name: ${friendly_name}
-  comment: ${device_description}
-  min_version: "2023.2.0"
-  platform: $platform
-  board: $board
-  project:
-    name: "esphome-econet.esphome-econet"
-    version: 0.3.0
+packages:
+  econet: !include econet_base.yaml
 
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/econet_heatpump_water_heater.yaml@main
   import_full_config: false
 
-preferences:
-  flash_write_interval: "24h"
-
-wifi:
-  ap:
-
-captive_portal:
-
-api:
-
-ota:
-
-logger:
-  baud_rate: 0  # Make sure logging is not using the serial port
-  level: ${logger_level}
-  tx_buffer_size: 2000
-
-external_components:
-  - source: ${external_components_source}
-
-uart:
-  id: uart_0
-  baud_rate: 38400
-  rx_buffer_size: 1500
-  tx_pin: ${tx_pin}
-  rx_pin: ${rx_pin}
-
 econet:
-  uart_id: uart_0
   model: "Heatpump"
-  update_interval: ${econet_update_interval}
 
 climate:
   - platform: econet
@@ -132,9 +88,6 @@ sensor:
     accuracy_decimals: 1
     device_class: "temperature"
     state_class: "measurement"
-    entity_category: "diagnostic"
-  - platform: wifi_signal
-    name: "WiFi Signal Strength"
     entity_category: "diagnostic"
 
 binary_sensor:

--- a/econet_hvac.yaml
+++ b/econet_hvac.yaml
@@ -3,60 +3,16 @@ substitutions:
   name: "econet-hvac"
   friendly_name: "Rheem HVAC"
   device_description: "Rheem HVAC"
-  tx_pin: GPIO19
-  rx_pin: GPIO22
-  platform: esp32
-  board: esp32dev
-  external_components_source: github://esphome-econet/esphome-econet@main
-  logger_level: WARN
-  econet_update_interval: 30s
 
-esphome:
-  name: ${name}
-  friendly_name: ${friendly_name}
-  comment: ${device_description}
-  min_version: "2023.2.0"
-  platform: $platform
-  board: $board
-  project:
-    name: "esphome-econet.esphome-econet"
-    version: 0.3.0
+packages:
+  econet: !include econet_base.yaml
 
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/econet_hvac.yaml@main
   import_full_config: false
 
-preferences:
-  flash_write_interval: "24h"
-
-wifi:
-  ap:
-
-captive_portal:
-
-api:
-
-ota:
-
-logger:
-  baud_rate: 0  # Make sure logging is not using the serial port
-  level: ${logger_level}
-  tx_buffer_size: 2000
-
-external_components:
-  - source: ${external_components_source}
-
-uart:
-  id: uart_0
-  baud_rate: 38400
-  rx_buffer_size: 1500
-  tx_pin: ${tx_pin}
-  rx_pin: ${rx_pin}
-
 econet:
-  uart_id: uart_0
   model: "HVAC"
-  update_interval: ${econet_update_interval}
   on_datapoint_update:
     - sensor_datapoint: AIRHSTAT
       datapoint_type: raw
@@ -186,9 +142,6 @@ sensor:
     accuracy_decimals: 0
     entity_category: "diagnostic"
     icon: "mdi:fan"
-  - platform: wifi_signal
-    name: "WiFi Signal Strength"
-    entity_category: "diagnostic"
 
 text_sensor:
   - platform: econet

--- a/econet_tankless_water_heater.yaml
+++ b/econet_tankless_water_heater.yaml
@@ -3,60 +3,16 @@ substitutions:
   name: "econet-tlwh"
   friendly_name: "Tankless Water Heater"
   device_description: "Rheem Tankless Water Heater"
-  tx_pin: GPIO19
-  rx_pin: GPIO22
-  platform: esp32
-  board: esp32dev
-  external_components_source: github://esphome-econet/esphome-econet@main
-  logger_level: WARN
-  econet_update_interval: 30s
 
-esphome:
-  name: ${name}
-  friendly_name: ${friendly_name}
-  comment: ${device_description}
-  min_version: "2023.2.0"
-  platform: $platform
-  board: $board
-  project:
-    name: "esphome-econet.esphome-econet"
-    version: 0.3.0
+packages:
+  econet: !include econet_base.yaml
 
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/econet_tankless_water_heater.yaml@main
   import_full_config: false
 
-preferences:
-  flash_write_interval: "24h"
-
-wifi:
-  ap:
-
-captive_portal:
-
-api:
-
-ota:
-
-logger:
-  baud_rate: 0  # Make sure logging is not using the serial port
-  level: ${logger_level}
-  tx_buffer_size: 2000
-
-external_components:
-  - source: ${external_components_source}
-
-uart:
-  id: uart_0
-  baud_rate: 38400
-  rx_buffer_size: 1500
-  tx_pin: ${tx_pin}
-  rx_pin: ${rx_pin}
-
 econet:
-  uart_id: uart_0
   model: "Tankless"
-  update_interval: ${econet_update_interval}
 
 climate:
   - platform: econet
@@ -129,6 +85,3 @@ sensor:
     lambda: |-
       return max((id(temp_out).state - id(temp_in).state) * id(flow_rate).state * 8.334 * 60 / 0.92 / 1000, 0.0);
     # yamllint enable rule:line-length
-  - platform: wifi_signal
-    name: "WiFi Signal Strength"
-    entity_category: "diagnostic"


### PR DESCRIPTION
This change removes all of the common configuration from the four main config files out to an `econet_base.yaml` file and references it via a `!include`. This appears to correctly pull in the base file for both local (proven by successful build Github Action to force local build) and remote (proven by deleting my local copy and still building with remote package set in my config yaml).