### PR TITLE
Adding model number and serial number diagnostic sensors.

### DIFF
--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -105,3 +105,13 @@ text_sensor:
     name: "Heating Element State"
     sensor_datapoint: HEATCTRL
     icon: "mdi:heating-coil"
+  - platform: econet
+    name: "Model Number"
+    sensor_datapoint: PRODMODN
+    icon: "mdi:information-box"
+    entity_category: "diagnostic"
+  - platform: econet
+    name: "Serial Number"
+    sensor_datapoint: PRODSERN
+    icon: "mdi:information-box"
+    entity_category: "diagnostic"


### PR DESCRIPTION
These may be supported on other units as well; it would require some testing to see. They were tested and not present on Tanked Electric Water Heaters.