### PR TITLE
Add ability to break up read requests using request_mod in yaml

### DIFF
--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -45,6 +45,13 @@ MODEL_TYPES = {
     "Electric Tank": ModelType.MODEL_TYPE_ELECTRIC_TANK,
 }
 
+
+def request_mod(value):
+    if isinstance(value, str) and value.lower() == "none":
+        return -1
+    return cv.int_range(min=-1, max=MAX_REQUEST_MOD)(value)
+
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -56,9 +63,7 @@ CONFIG_SCHEMA = (
                         DATAPOINT_TRIGGERS[DPTYPE_RAW]
                     ),
                     cv.Required(CONF_SENSOR_DATAPOINT): cv.string,
-                    cv.Optional(CONF_REQUEST_MOD, default=-1): cv.int_range(
-                        min=-1, max=MAX_REQUEST_MOD
-                    ),
+                    cv.Optional(CONF_REQUEST_MOD, default="none"): request_mod,
                     cv.Optional(CONF_DATAPOINT_TYPE, default=DPTYPE_RAW): cv.one_of(
                         *DATAPOINT_TRIGGERS, lower=True
                     ),
@@ -75,9 +80,7 @@ CONF_ECONET_ID = "econet_id"
 ECONET_CLIENT_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ECONET_ID): cv.use_id(Econet),
-        cv.Optional(CONF_REQUEST_MOD, default=0): cv.int_range(
-            min=-1, max=MAX_REQUEST_MOD
-        ),
+        cv.Optional(CONF_REQUEST_MOD, default=0): request_mod,
     }
 )
 

--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -9,7 +9,6 @@ DEPENDENCIES = ["uart"]
 CONF_ON_DATAPOINT_UPDATE = "on_datapoint_update"
 CONF_DATAPOINT_TYPE = "datapoint_type"
 CONF_REQUEST_MOD = "request_mod"
-MAX_REQUEST_MOD = 7
 
 econet_ns = cg.esphome_ns.namespace("econet")
 Econet = econet_ns.class_("Econet", cg.Component, uart.UARTDevice)
@@ -49,7 +48,7 @@ MODEL_TYPES = {
 def request_mod(value):
     if isinstance(value, str) and value.lower() == "none":
         return -1
-    return cv.int_range(min=-1, max=MAX_REQUEST_MOD)(value)
+    return cv.int_range(min=0, max=7)(value)
 
 
 CONFIG_SCHEMA = (

--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -8,6 +8,8 @@ DEPENDENCIES = ["uart"]
 
 CONF_ON_DATAPOINT_UPDATE = "on_datapoint_update"
 CONF_DATAPOINT_TYPE = "datapoint_type"
+CONF_REQUEST_MOD = "request_mod"
+MAX_REQUEST_MOD = 7
 
 econet_ns = cg.esphome_ns.namespace("econet")
 Econet = econet_ns.class_("Econet", cg.Component, uart.UARTDevice)
@@ -54,6 +56,9 @@ CONFIG_SCHEMA = (
                         DATAPOINT_TRIGGERS[DPTYPE_RAW]
                     ),
                     cv.Required(CONF_SENSOR_DATAPOINT): cv.string,
+                    cv.Optional(CONF_REQUEST_MOD, default=-1): cv.int_range(
+                        min=-1, max=MAX_REQUEST_MOD
+                    ),
                     cv.Optional(CONF_DATAPOINT_TYPE, default=DPTYPE_RAW): cv.one_of(
                         *DATAPOINT_TRIGGERS, lower=True
                     ),
@@ -67,11 +72,12 @@ CONFIG_SCHEMA = (
 )
 
 CONF_ECONET_ID = "econet_id"
-CONF_LISTEN_ONLY = "listen_only"
 ECONET_CLIENT_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ECONET_ID): cv.use_id(Econet),
-        cv.Optional(CONF_LISTEN_ONLY, default=False): cv.boolean,
+        cv.Optional(CONF_REQUEST_MOD, default=0): cv.int_range(
+            min=-1, max=MAX_REQUEST_MOD
+        ),
     }
 )
 
@@ -83,7 +89,10 @@ async def to_code(config):
     cg.add(var.set_model_type(config[CONF_MODEL]))
     for conf in config.get(CONF_ON_DATAPOINT_UPDATE, []):
         trigger = cg.new_Pvariable(
-            conf[CONF_TRIGGER_ID], var, conf[CONF_SENSOR_DATAPOINT]
+            conf[CONF_TRIGGER_ID],
+            var,
+            conf[CONF_SENSOR_DATAPOINT],
+            conf[CONF_REQUEST_MOD],
         )
         await automation.build_automation(
             trigger, [(DATAPOINT_TYPES[conf[CONF_DATAPOINT_TYPE]], "x")], conf

--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -67,9 +67,11 @@ CONFIG_SCHEMA = (
 )
 
 CONF_ECONET_ID = "econet_id"
+CONF_LISTEN_ONLY = "listen_only"
 ECONET_CLIENT_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ECONET_ID): cv.use_id(Econet),
+        cv.Optional(CONF_LISTEN_ONLY, default=False): cv.boolean,
     }
 )
 

--- a/components/econet/automation.cpp
+++ b/components/econet/automation.cpp
@@ -8,8 +8,10 @@ namespace esphome {
 namespace econet {
 
 EconetRawDatapointUpdateTrigger::EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id) {
-  parent->register_listener(
-      sensor_id, [this](const EconetDatapoint &dp) { this->trigger(dp.value_raw); }, true);
+  // RAW datapoints need to be requested separately.
+  // For now rely on other devices, e.g. thermostat, requesting them.
+  bool listen_only = true;
+  parent->register_listener(sensor_id, listen_only, [this](const EconetDatapoint &dp) { this->trigger(dp.value_raw); });
 }
 
 }  // namespace econet

--- a/components/econet/automation.cpp
+++ b/components/econet/automation.cpp
@@ -7,11 +7,9 @@ static const char *const TAG = "econet.automation";
 namespace esphome {
 namespace econet {
 
-EconetRawDatapointUpdateTrigger::EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id) {
-  // RAW datapoints need to be requested separately.
-  // For now rely on other devices, e.g. thermostat, requesting them.
-  bool listen_only = true;
-  parent->register_listener(sensor_id, listen_only, [this](const EconetDatapoint &dp) { this->trigger(dp.value_raw); });
+EconetRawDatapointUpdateTrigger::EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id,
+                                                                 int8_t request_mod) {
+  parent->register_listener(sensor_id, request_mod, [this](const EconetDatapoint &dp) { this->trigger(dp.value_raw); });
 }
 
 }  // namespace econet

--- a/components/econet/automation.h
+++ b/components/econet/automation.h
@@ -11,7 +11,7 @@ namespace econet {
 
 class EconetRawDatapointUpdateTrigger : public Trigger<std::vector<uint8_t>> {
  public:
-  explicit EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id);
+  explicit EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id, int8_t request_mod);
 };
 
 }  // namespace econet

--- a/components/econet/binary_sensor/__init__.py
+++ b/components/econet/binary_sensor/__init__.py
@@ -3,7 +3,13 @@ import esphome.config_validation as cv
 from esphome.components import binary_sensor
 from esphome.const import CONF_SENSOR_DATAPOINT
 
-from .. import CONF_ECONET_ID, ECONET_CLIENT_SCHEMA, EconetClient, econet_ns
+from .. import (
+    CONF_ECONET_ID,
+    CONF_LISTEN_ONLY,
+    ECONET_CLIENT_SCHEMA,
+    EconetClient,
+    econet_ns,
+)
 
 DEPENDENCIES = ["econet"]
 
@@ -29,5 +35,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-
+    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
     cg.add(var.set_sensor_id(config[CONF_SENSOR_DATAPOINT]))

--- a/components/econet/binary_sensor/__init__.py
+++ b/components/econet/binary_sensor/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_SENSOR_DATAPOINT
 
 from .. import (
     CONF_ECONET_ID,
-    CONF_LISTEN_ONLY,
+    CONF_REQUEST_MOD,
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
@@ -35,5 +35,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
+    cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))
     cg.add(var.set_sensor_id(config[CONF_SENSOR_DATAPOINT]))

--- a/components/econet/binary_sensor/econet_binary_sensor.cpp
+++ b/components/econet/binary_sensor/econet_binary_sensor.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.binary_sensor";
 
 void EconetBinarySensor::setup() {
-  this->parent_->register_listener(this->sensor_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->sensor_id_, this->request_mod_, [this](const EconetDatapoint &datapoint) {
     ESP_LOGV(TAG, "MCU reported binary sensor %s is: %s", this->sensor_id_.c_str(), ONOFF(datapoint.value_enum));
     this->publish_state(datapoint.value_enum);
   });

--- a/components/econet/binary_sensor/econet_binary_sensor.cpp
+++ b/components/econet/binary_sensor/econet_binary_sensor.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.binary_sensor";
 
 void EconetBinarySensor::setup() {
-  this->parent_->register_listener(this->sensor_id_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->sensor_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
     ESP_LOGV(TAG, "MCU reported binary sensor %s is: %s", this->sensor_id_.c_str(), ONOFF(datapoint.value_enum));
     this->publish_state(datapoint.value_enum);
   });

--- a/components/econet/climate/__init__.py
+++ b/components/econet/climate/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID
 
 from .. import (
     CONF_ECONET_ID,
-    CONF_LISTEN_ONLY,
+    CONF_REQUEST_MOD,
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
@@ -35,4 +35,4 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
+    cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))

--- a/components/econet/climate/__init__.py
+++ b/components/econet/climate/__init__.py
@@ -3,7 +3,13 @@ import esphome.config_validation as cv
 from esphome.components import climate
 from esphome.const import CONF_ID
 
-from .. import CONF_ECONET_ID, ECONET_CLIENT_SCHEMA, EconetClient, econet_ns
+from .. import (
+    CONF_ECONET_ID,
+    CONF_LISTEN_ONLY,
+    ECONET_CLIENT_SCHEMA,
+    EconetClient,
+    econet_ns,
+)
 
 DEPENDENCIES = ["econet"]
 
@@ -29,3 +35,4 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
+    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))

--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -62,32 +62,32 @@ climate::ClimateTraits EconetClimate::traits() {
 void EconetClimate::setup() {
   ModelType model_type = this->parent_->get_model_type();
   if (model_type == MODEL_TYPE_HVAC) {
-    this->parent_->register_listener("HEATSETP", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("HEATSETP", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       this->target_temperature_low = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
-    this->parent_->register_listener("COOLSETP", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("COOLSETP", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       this->target_temperature_high = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
-    this->parent_->register_listener("SPT_STAT", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("SPT_STAT", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       this->current_temperature = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
   } else {
-    this->parent_->register_listener("WHTRSETP", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRSETP", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       this->target_temperature = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
     this->parent_->register_listener(
         (model_type == MODEL_TYPE_HEATPUMP || model_type == MODEL_TYPE_ELECTRIC_TANK) ? "UPHTRTMP" : "TEMP_OUT",
-        [this](const EconetDatapoint &datapoint) {
+        this->listen_only_, [this](const EconetDatapoint &datapoint) {
           this->current_temperature = fahrenheit_to_celsius(datapoint.value_float);
           this->publish_state();
         });
   }
   if (model_type == MODEL_TYPE_HVAC) {
-    this->parent_->register_listener("STATMODE", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("STATMODE", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->mode = climate::CLIMATE_MODE_HEAT;
@@ -107,7 +107,7 @@ void EconetClimate::setup() {
       }
       this->publish_state();
     });
-    this->parent_->register_listener("STATNFAN", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("STATNFAN", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->set_custom_fan_mode_("Automatic");
@@ -131,7 +131,7 @@ void EconetClimate::setup() {
       this->publish_state();
     });
   } else {
-    this->parent_->register_listener("WHTRENAB", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRENAB", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       if (datapoint.value_enum == 1) {
         this->mode = climate::CLIMATE_MODE_AUTO;
       } else {
@@ -141,7 +141,7 @@ void EconetClimate::setup() {
     });
   }
   if (model_type == MODEL_TYPE_HEATPUMP) {
-    this->parent_->register_listener("WHTRCNFG", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRCNFG", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->set_custom_preset_("Off");
@@ -165,7 +165,7 @@ void EconetClimate::setup() {
       this->publish_state();
     });
   } else if (model_type == MODEL_TYPE_ELECTRIC_TANK) {
-    this->parent_->register_listener("WHTRCNFG", [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRCNFG", this->listen_only_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->set_custom_preset_("Energy Saver");

--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -62,32 +62,32 @@ climate::ClimateTraits EconetClimate::traits() {
 void EconetClimate::setup() {
   ModelType model_type = this->parent_->get_model_type();
   if (model_type == MODEL_TYPE_HVAC) {
-    this->parent_->register_listener("HEATSETP", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("HEATSETP", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       this->target_temperature_low = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
-    this->parent_->register_listener("COOLSETP", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("COOLSETP", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       this->target_temperature_high = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
-    this->parent_->register_listener("SPT_STAT", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("SPT_STAT", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       this->current_temperature = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
   } else {
-    this->parent_->register_listener("WHTRSETP", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRSETP", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       this->target_temperature = fahrenheit_to_celsius(datapoint.value_float);
       this->publish_state();
     });
     this->parent_->register_listener(
         (model_type == MODEL_TYPE_HEATPUMP || model_type == MODEL_TYPE_ELECTRIC_TANK) ? "UPHTRTMP" : "TEMP_OUT",
-        this->listen_only_, [this](const EconetDatapoint &datapoint) {
+        this->request_mod_, [this](const EconetDatapoint &datapoint) {
           this->current_temperature = fahrenheit_to_celsius(datapoint.value_float);
           this->publish_state();
         });
   }
   if (model_type == MODEL_TYPE_HVAC) {
-    this->parent_->register_listener("STATMODE", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("STATMODE", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->mode = climate::CLIMATE_MODE_HEAT;
@@ -107,7 +107,7 @@ void EconetClimate::setup() {
       }
       this->publish_state();
     });
-    this->parent_->register_listener("STATNFAN", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("STATNFAN", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->set_custom_fan_mode_("Automatic");
@@ -131,7 +131,7 @@ void EconetClimate::setup() {
       this->publish_state();
     });
   } else {
-    this->parent_->register_listener("WHTRENAB", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRENAB", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       if (datapoint.value_enum == 1) {
         this->mode = climate::CLIMATE_MODE_AUTO;
       } else {
@@ -141,7 +141,7 @@ void EconetClimate::setup() {
     });
   }
   if (model_type == MODEL_TYPE_HEATPUMP) {
-    this->parent_->register_listener("WHTRCNFG", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRCNFG", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->set_custom_preset_("Off");
@@ -165,7 +165,7 @@ void EconetClimate::setup() {
       this->publish_state();
     });
   } else if (model_type == MODEL_TYPE_ELECTRIC_TANK) {
-    this->parent_->register_listener("WHTRCNFG", this->listen_only_, [this](const EconetDatapoint &datapoint) {
+    this->parent_->register_listener("WHTRCNFG", this->request_mod_, [this](const EconetDatapoint &datapoint) {
       switch (datapoint.value_enum) {
         case 0:
           this->set_custom_preset_("Energy Saver");

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -503,11 +503,9 @@ void Econet::send_datapoint_(const std::string &datapoint_id, const EconetDatapo
   }
 }
 
-void Econet::register_listener(const std::string &datapoint_id, const std::function<void(EconetDatapoint)> &func,
-                               bool is_raw_datapoint) {
-  // Don't issue a READ_COMMAND in request_strings_ for RAW datapoints. These need to be requested separately.
-  // For now rely on other devices, e.g. thermostat, requesting them.
-  if (!is_raw_datapoint) {
+void Econet::register_listener(const std::string &datapoint_id, bool listen_only,
+                               const std::function<void(EconetDatapoint)> &func) {
+  if (!listen_only) {
     datapoint_ids_.insert(datapoint_id);
   }
   auto listener = EconetDatapointListener{

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -210,8 +210,7 @@ void Econet::make_request_() {
     return;
   }
 
-  std::vector<std::string> str_ids(datapoint_ids_.begin(), datapoint_ids_.end());
-  request_strings_(dst_adr, src_adr, str_ids);
+  request_strings_(dst_adr, src_adr);
 }
 
 void Econet::parse_tx_message_() { this->parse_message_(true); }
@@ -374,7 +373,7 @@ void Econet::loop() {
 
   // Quickly send writes but delay reads.
   if (!pending_writes_.empty() || !pending_confirmation_writes_.empty() ||
-      (now - this->last_request_ > this->update_interval_millis_)) {
+      (now - this->last_request_ > this->update_interval_millis_ / request_mods_)) {
     ESP_LOGI(TAG, "request ms=%d", now);
     this->last_request_ = now;
     this->make_request_();
@@ -406,10 +405,15 @@ void Econet::write_value_(uint32_t dst_adr, uint32_t src_adr, const std::string 
   transmit_message_(dst_adr, src_adr, WRITE_COMMAND, data);
 }
 
-void Econet::request_strings_(uint32_t dst_adr, uint32_t src_adr, const std::vector<std::string> &objects) {
+void Econet::request_strings_(uint32_t dst_adr, uint32_t src_adr) {
+  uint8_t request_mod = read_requests_++ % request_mods_;
+  const std::vector<std::string> &objects = request_datapoint_ids_[request_mod];
+
   std::vector<uint8_t> data;
 
-  if (objects.size() > 1) {
+  if (objects.empty()) {
+    return;
+  } else if (objects.size() > 1) {
     // Read Class
     data.push_back(2);
   } else {
@@ -503,10 +507,14 @@ void Econet::send_datapoint_(const std::string &datapoint_id, const EconetDatapo
   }
 }
 
-void Econet::register_listener(const std::string &datapoint_id, bool listen_only,
+void Econet::register_listener(const std::string &datapoint_id, int8_t request_mod,
                                const std::function<void(EconetDatapoint)> &func) {
-  if (!listen_only) {
-    datapoint_ids_.insert(datapoint_id);
+  if (request_mod >= 0 && request_mod < request_datapoint_ids_.size()) {
+    auto dids = &request_datapoint_ids_[request_mod];
+    if (std::find(dids->begin(), dids->end(), datapoint_id) == dids->end()) {
+      dids->push_back(datapoint_id);
+    }
+    request_mods_ = std::max(request_mods_, (uint8_t) (request_mod + 1));
   }
   auto listener = EconetDatapointListener{
       .datapoint_id = datapoint_id,

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -405,7 +405,8 @@ void Econet::write_value_(uint32_t dst_adr, uint32_t src_adr, const std::string 
 
 void Econet::request_strings_(uint32_t dst_adr, uint32_t src_adr) {
   uint8_t request_mod = read_requests_++ % request_mods_;
-  const std::vector<std::string> &objects = request_datapoint_ids_[request_mod];
+  std::vector<std::string> objects(request_datapoint_ids_[request_mod].begin(),
+                                   request_datapoint_ids_[request_mod].end());
 
   std::vector<uint8_t> data;
 
@@ -499,10 +500,7 @@ void Econet::send_datapoint_(const std::string &datapoint_id, const EconetDatapo
 void Econet::register_listener(const std::string &datapoint_id, int8_t request_mod,
                                const std::function<void(EconetDatapoint)> &func) {
   if (request_mod >= 0 && request_mod < request_datapoint_ids_.size()) {
-    auto dids = &request_datapoint_ids_[request_mod];
-    if (std::find(dids->begin(), dids->end(), datapoint_id) == dids->end()) {
-      dids->push_back(datapoint_id);
-    }
+    request_datapoint_ids_[request_mod].insert(datapoint_id);
     request_mods_ = std::max(request_mods_, (uint8_t) (request_mod + 1));
   }
   auto listener = EconetDatapointListener{

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -108,7 +108,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::vector<uint8_t> rx_message_;
   std::vector<uint8_t> tx_message_;
 
-  uint32_t dst_adr_ = 0;
+  uint32_t dst_adr_{0};
 };
 
 class EconetClient {
@@ -118,7 +118,7 @@ class EconetClient {
 
  protected:
   Econet *parent_;
-  bool listen_only_ = false;
+  bool listen_only_{false};
 };
 
 }  // namespace econet

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -76,8 +76,8 @@ class Econet : public Component, public uart::UARTDevice {
   void set_float_datapoint_value(const std::string &datapoint_id, float value);
   void set_enum_datapoint_value(const std::string &datapoint_id, uint8_t value);
 
-  void register_listener(const std::string &datapoint_id, const std::function<void(EconetDatapoint)> &func,
-                         bool is_raw_datapoint = false);
+  void register_listener(const std::string &datapoint_id, bool listen_only,
+                         const std::function<void(EconetDatapoint)> &func);
 
  protected:
   ModelType model_type_;
@@ -114,9 +114,11 @@ class Econet : public Component, public uart::UARTDevice {
 class EconetClient {
  public:
   void set_econet_parent(Econet *parent) { this->parent_ = parent; }
+  void set_listen_only(bool listen_only) { this->listen_only_ = listen_only; }
 
  protected:
   Econet *parent_;
+  bool listen_only_ = false;
 };
 
 }  // namespace econet

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -76,7 +76,7 @@ class Econet : public Component, public uart::UARTDevice {
   void set_float_datapoint_value(const std::string &datapoint_id, float value);
   void set_enum_datapoint_value(const std::string &datapoint_id, uint8_t value);
 
-  void register_listener(const std::string &datapoint_id, bool listen_only,
+  void register_listener(const std::string &datapoint_id, int8_t request_mod,
                          const std::function<void(EconetDatapoint)> &func);
 
  protected:
@@ -94,15 +94,17 @@ class Econet : public Component, public uart::UARTDevice {
   void parse_tx_message_();
 
   void transmit_message_(uint32_t dst_adr, uint32_t src_adr, uint8_t command, const std::vector<uint8_t> &data);
-  void request_strings_(uint32_t dst_adr, uint32_t src_adr, const std::vector<std::string> &objects);
+  void request_strings_(uint32_t dst_adr, uint32_t src_adr);
   void write_value_(uint32_t dst_adr, uint32_t src_adr, const std::string &object, EconetDatapointType type,
                     float value);
 
-  std::set<std::string> datapoint_ids_{};
-  std::map<std::string, EconetDatapoint> datapoints_{};
-  std::map<std::string, EconetDatapoint> pending_writes_{};
-  std::map<std::string, EconetDatapoint> pending_confirmation_writes_{};
+  std::vector<std::vector<std::string>> request_datapoint_ids_ = std::vector<std::vector<std::string>>(8);
+  uint8_t request_mods_{1};
+  std::map<std::string, EconetDatapoint> datapoints_;
+  std::map<std::string, EconetDatapoint> pending_writes_;
+  std::map<std::string, EconetDatapoint> pending_confirmation_writes_;
 
+  uint32_t read_requests_{0};
   uint32_t last_request_{0};
   uint32_t last_read_data_{0};
   std::vector<uint8_t> rx_message_;
@@ -114,11 +116,11 @@ class Econet : public Component, public uart::UARTDevice {
 class EconetClient {
  public:
   void set_econet_parent(Econet *parent) { this->parent_ = parent; }
-  void set_listen_only(bool listen_only) { this->listen_only_ = listen_only; }
+  void set_request_mod(int8_t request_mod) { this->request_mod_ = request_mod; }
 
  protected:
   Econet *parent_;
-  bool listen_only_{false};
+  int8_t request_mod_{0};
 };
 
 }  // namespace econet

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -98,7 +98,7 @@ class Econet : public Component, public uart::UARTDevice {
   void write_value_(uint32_t dst_adr, uint32_t src_adr, const std::string &object, EconetDatapointType type,
                     float value);
 
-  std::vector<std::vector<std::string>> request_datapoint_ids_ = std::vector<std::vector<std::string>>(8);
+  std::vector<std::set<std::string>> request_datapoint_ids_ = std::vector<std::set<std::string>>(8);
   uint8_t request_mods_{1};
   std::map<std::string, EconetDatapoint> datapoints_;
   std::map<std::string, EconetDatapoint> pending_writes_;

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -102,7 +102,6 @@ class Econet : public Component, public uart::UARTDevice {
   uint8_t request_mods_{1};
   std::map<std::string, EconetDatapoint> datapoints_;
   std::map<std::string, EconetDatapoint> pending_writes_;
-  std::map<std::string, EconetDatapoint> pending_confirmation_writes_;
 
   uint32_t read_requests_{0};
   uint32_t last_request_{0};

--- a/components/econet/number/__init__.py
+++ b/components/econet/number/__init__.py
@@ -9,7 +9,13 @@ from esphome.const import (
     CONF_STEP,
 )
 
-from .. import CONF_ECONET_ID, ECONET_CLIENT_SCHEMA, EconetClient, econet_ns
+from .. import (
+    CONF_ECONET_ID,
+    CONF_LISTEN_ONLY,
+    ECONET_CLIENT_SCHEMA,
+    EconetClient,
+    econet_ns,
+)
 
 DEPENDENCIES = ["econet"]
 
@@ -53,5 +59,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-
+    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
     cg.add(var.set_number_id(config[CONF_NUMBER_DATAPOINT]))

--- a/components/econet/number/__init__.py
+++ b/components/econet/number/__init__.py
@@ -11,7 +11,7 @@ from esphome.const import (
 
 from .. import (
     CONF_ECONET_ID,
-    CONF_LISTEN_ONLY,
+    CONF_REQUEST_MOD,
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
@@ -59,5 +59,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
+    cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))
     cg.add(var.set_number_id(config[CONF_NUMBER_DATAPOINT]))

--- a/components/econet/number/econet_number.cpp
+++ b/components/econet/number/econet_number.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.number";
 
 void EconetNumber::setup() {
-  this->parent_->register_listener(this->number_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->number_id_, this->request_mod_, [this](const EconetDatapoint &datapoint) {
     if (datapoint.type == EconetDatapointType::FLOAT) {
       ESP_LOGV(TAG, "MCU reported number %s is: %f", this->number_id_.c_str(), datapoint.value_float);
       this->publish_state(datapoint.value_float);

--- a/components/econet/number/econet_number.cpp
+++ b/components/econet/number/econet_number.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.number";
 
 void EconetNumber::setup() {
-  this->parent_->register_listener(this->number_id_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->number_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
     if (datapoint.type == EconetDatapointType::FLOAT) {
       ESP_LOGV(TAG, "MCU reported number %s is: %f", this->number_id_.c_str(), datapoint.value_float);
       this->publish_state(datapoint.value_float);

--- a/components/econet/sensor/__init__.py
+++ b/components/econet/sensor/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT
 
 from .. import (
     CONF_ECONET_ID,
-    CONF_LISTEN_ONLY,
+    CONF_REQUEST_MOD,
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
@@ -36,5 +36,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
+    cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))
     cg.add(var.set_sensor_id(config[CONF_SENSOR_DATAPOINT]))

--- a/components/econet/sensor/__init__.py
+++ b/components/econet/sensor/__init__.py
@@ -3,7 +3,13 @@ import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT
 
-from .. import CONF_ECONET_ID, ECONET_CLIENT_SCHEMA, EconetClient, econet_ns
+from .. import (
+    CONF_ECONET_ID,
+    CONF_LISTEN_ONLY,
+    ECONET_CLIENT_SCHEMA,
+    EconetClient,
+    econet_ns,
+)
 
 DEPENDENCIES = ["econet"]
 
@@ -30,5 +36,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-
+    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
     cg.add(var.set_sensor_id(config[CONF_SENSOR_DATAPOINT]))

--- a/components/econet/sensor/econet_sensor.cpp
+++ b/components/econet/sensor/econet_sensor.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.sensor";
 
 void EconetSensor::setup() {
-  this->parent_->register_listener(this->sensor_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->sensor_id_, this->request_mod_, [this](const EconetDatapoint &datapoint) {
     if (datapoint.type == EconetDatapointType::FLOAT) {
       ESP_LOGV(TAG, "MCU reported sensor %s is: %f", this->sensor_id_.c_str(), datapoint.value_float);
       this->publish_state(datapoint.value_float);

--- a/components/econet/sensor/econet_sensor.cpp
+++ b/components/econet/sensor/econet_sensor.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.sensor";
 
 void EconetSensor::setup() {
-  this->parent_->register_listener(this->sensor_id_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->sensor_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
     if (datapoint.type == EconetDatapointType::FLOAT) {
       ESP_LOGV(TAG, "MCU reported sensor %s is: %f", this->sensor_id_.c_str(), datapoint.value_float);
       this->publish_state(datapoint.value_float);

--- a/components/econet/switch/__init__.py
+++ b/components/econet/switch/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_SWITCH_DATAPOINT
 
 from .. import (
     CONF_ECONET_ID,
-    CONF_LISTEN_ONLY,
+    CONF_REQUEST_MOD,
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
@@ -35,5 +35,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
+    cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))
     cg.add(var.set_switch_id(config[CONF_SWITCH_DATAPOINT]))

--- a/components/econet/switch/__init__.py
+++ b/components/econet/switch/__init__.py
@@ -3,7 +3,13 @@ import esphome.config_validation as cv
 from esphome.components import switch
 from esphome.const import CONF_SWITCH_DATAPOINT
 
-from .. import CONF_ECONET_ID, ECONET_CLIENT_SCHEMA, EconetClient, econet_ns
+from .. import (
+    CONF_ECONET_ID,
+    CONF_LISTEN_ONLY,
+    ECONET_CLIENT_SCHEMA,
+    EconetClient,
+    econet_ns,
+)
 
 DEPENDENCIES = ["econet"]
 
@@ -29,5 +35,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-
+    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
     cg.add(var.set_switch_id(config[CONF_SWITCH_DATAPOINT]))

--- a/components/econet/switch/econet_switch.cpp
+++ b/components/econet/switch/econet_switch.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.switch";
 
 void EconetSwitch::setup() {
-  this->parent_->register_listener(this->switch_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->switch_id_, this->request_mod_, [this](const EconetDatapoint &datapoint) {
     ESP_LOGV(TAG, "MCU reported switch %s is: %s", this->switch_id_.c_str(), ONOFF(datapoint.value_enum));
     this->publish_state(datapoint.value_enum);
   });

--- a/components/econet/switch/econet_switch.cpp
+++ b/components/econet/switch/econet_switch.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.switch";
 
 void EconetSwitch::setup() {
-  this->parent_->register_listener(this->switch_id_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->switch_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
     ESP_LOGV(TAG, "MCU reported switch %s is: %s", this->switch_id_.c_str(), ONOFF(datapoint.value_enum));
     this->publish_state(datapoint.value_enum);
   });

--- a/components/econet/text_sensor/__init__.py
+++ b/components/econet/text_sensor/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_SENSOR_DATAPOINT
 
 from .. import (
     CONF_ECONET_ID,
-    CONF_LISTEN_ONLY,
+    CONF_REQUEST_MOD,
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
@@ -36,5 +36,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
+    cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))
     cg.add(var.set_sensor_id(config[CONF_SENSOR_DATAPOINT]))

--- a/components/econet/text_sensor/__init__.py
+++ b/components/econet/text_sensor/__init__.py
@@ -3,7 +3,13 @@ import esphome.config_validation as cv
 from esphome.components import text_sensor
 from esphome.const import CONF_SENSOR_DATAPOINT
 
-from .. import CONF_ECONET_ID, ECONET_CLIENT_SCHEMA, EconetClient, econet_ns
+from .. import (
+    CONF_ECONET_ID,
+    CONF_LISTEN_ONLY,
+    ECONET_CLIENT_SCHEMA,
+    EconetClient,
+    econet_ns,
+)
 
 DEPENDENCIES = ["econet"]
 
@@ -30,5 +36,5 @@ async def to_code(config):
 
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
-
+    cg.add(var.set_listen_only(config[CONF_LISTEN_ONLY]))
     cg.add(var.set_sensor_id(config[CONF_SENSOR_DATAPOINT]))

--- a/components/econet/text_sensor/econet_text_sensor.cpp
+++ b/components/econet/text_sensor/econet_text_sensor.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.text_sensor";
 
 void EconetTextSensor::setup() {
-  this->parent_->register_listener(this->sensor_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->sensor_id_, this->request_mod_, [this](const EconetDatapoint &datapoint) {
     ESP_LOGD(TAG, "MCU reported text sensor %s is: %s", this->sensor_id_.c_str(), datapoint.value_string.c_str());
     this->publish_state(datapoint.value_string);
   });

--- a/components/econet/text_sensor/econet_text_sensor.cpp
+++ b/components/econet/text_sensor/econet_text_sensor.cpp
@@ -7,7 +7,7 @@ namespace econet {
 static const char *const TAG = "econet.text_sensor";
 
 void EconetTextSensor::setup() {
-  this->parent_->register_listener(this->sensor_id_, [this](const EconetDatapoint &datapoint) {
+  this->parent_->register_listener(this->sensor_id_, this->listen_only_, [this](const EconetDatapoint &datapoint) {
     ESP_LOGD(TAG, "MCU reported text sensor %s is: %s", this->sensor_id_.c_str(), datapoint.value_string.c_str());
     this->publish_state(datapoint.value_string);
   });


### PR DESCRIPTION
For #61, ALARM_01 to ALARM_04 need to be requested separately. Achieve this by introducing request_mod option in yaml.

The new sensors will be defined in a follow up PR as:

```yaml
text_sensor:
  - platform: econet
    name: "Alarm 1"
    sensor_datapoint: ALARM_01
    request_mod: 1
  - platform: econet
    name: "Alarm 2"
    sensor_datapoint: ALARM_02
    request_mod: 1
  - platform: econet
    name: "Alarm 3"
    sensor_datapoint: ALARM_03
    request_mod: 1
  - platform: econet
    name: "Alarm 4"
    sensor_datapoint: ALARM_04
    request_mod: 1
```

All the other sensors default to `request_mod: 0` so they will be requested together.

The RAW on_datapoint_update triggers also support request_mod. However it defaults to none (or internally to -1) to keep previous behavior, i.e. not request them but instead listen on them.

This change also allows setting `request_mod: none` for many upcoming HVAC sensors that don't need to be requested explicitly since we can just listen on the thermostat requests.

Also remove retrying writes. With the better logic when it's ready to send messages added in #49 this retry shouldn't be needed anymore.