### PR TITLE
Fix write bug for ALRESET and similar switches

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -491,23 +491,18 @@ void Econet::set_datapoint_(const std::string &datapoint_id, const EconetDatapoi
     }
   }
   pending_writes_[datapoint_id] = value;
-  if (rx_message_.empty()) {
-    make_request_();
-  }
-  send_datapoint_(datapoint_id, value, true);
+  send_datapoint_(datapoint_id, value);
 }
 
-void Econet::send_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value, bool skip_update_state) {
-  if (!skip_update_state) {
-    if (datapoints_.count(datapoint_id) == 1) {
-      EconetDatapoint old_value = datapoints_[datapoint_id];
-      if (old_value == value) {
-        ESP_LOGV(TAG, "Not sending unchanged value for datapoint %s", datapoint_id.c_str());
-        return;
-      }
+void Econet::send_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value) {
+  if (datapoints_.count(datapoint_id) == 1) {
+    EconetDatapoint old_value = datapoints_[datapoint_id];
+    if (old_value == value) {
+      ESP_LOGV(TAG, "Not sending unchanged value for datapoint %s", datapoint_id.c_str());
+      return;
     }
-    datapoints_[datapoint_id] = value;
   }
+  datapoints_[datapoint_id] = value;
   for (auto &listener : this->listeners_) {
     if (listener.datapoint_id == datapoint_id) {
       listener.on_datapoint(value);

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -86,7 +86,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::vector<EconetDatapointListener> listeners_;
   ReadRequest read_req_;
   void set_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value);
-  void send_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value, bool skip_update_state = false);
+  void send_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value);
 
   void make_request_();
   void read_buffer_(int bytes_available);


### PR DESCRIPTION
For resetting alarms and similar switches, the switches were getting stuck at the on position.
If you turn the switch to on, the subsequent read would still get `ALRESET : 0 (No)`, and since we had skipped updating the internal state in memory this line https://github.com/esphome-econet/esphome-econet/blob/ecd3297287dec45277deaf8c5f05439f7637b3ac/components/econet/econet.cpp#L505 would skip updating the switch component.
A similar issue can manifest if you change e.g. the climate mode and before the subsequent read completes you change the mode back to the previous value from the unit itself.
The skip_update_state was needed earlier for retrying writes but that logic has been removed.