### PR TITLE
Move all device specific configuration into yaml

### DIFF
--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -2,10 +2,12 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import uart
-from esphome.const import CONF_ID, CONF_MODEL, CONF_SENSOR_DATAPOINT, CONF_TRIGGER_ID
+from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT, CONF_TRIGGER_ID
 
 DEPENDENCIES = ["uart"]
 
+CONF_SRC_ADDRESS = "src_address"
+CONF_DST_ADDRESS = "dst_address"
 CONF_ON_DATAPOINT_UPDATE = "on_datapoint_update"
 CONF_DATAPOINT_TYPE = "datapoint_type"
 CONF_REQUEST_MOD = "request_mod"
@@ -37,15 +39,6 @@ def assign_declare_id(value):
     return value
 
 
-ModelType = econet_ns.enum("ModelType")
-MODEL_TYPES = {
-    "Tankless": ModelType.MODEL_TYPE_TANKLESS,
-    "Heatpump": ModelType.MODEL_TYPE_HEATPUMP,
-    "HVAC": ModelType.MODEL_TYPE_HVAC,
-    "Electric Tank": ModelType.MODEL_TYPE_ELECTRIC_TANK,
-}
-
-
 def request_mod(value):
     if isinstance(value, str) and value.lower() == "none":
         return -1
@@ -56,7 +49,8 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Econet),
-            cv.Required(CONF_MODEL): cv.enum(MODEL_TYPES),
+            cv.Required(CONF_SRC_ADDRESS): cv.uint32_t,
+            cv.Optional(CONF_DST_ADDRESS, default="0"): cv.uint32_t,
             cv.Optional(CONF_ON_DATAPOINT_UPDATE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -90,7 +84,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    cg.add(var.set_model_type(config[CONF_MODEL]))
+    cg.add(var.set_src_address(config[CONF_SRC_ADDRESS]))
+    cg.add(var.set_dst_address(config[CONF_DST_ADDRESS]))
     for conf in config.get(CONF_ON_DATAPOINT_UPDATE, []):
         trigger = cg.new_Pvariable(
             conf[CONF_TRIGGER_ID],

--- a/components/econet/climate/__init__.py
+++ b/components/econet/climate/__init__.py
@@ -14,14 +14,58 @@ from .. import (
 
 DEPENDENCIES = ["econet"]
 
+CONF_CURRENT_TEMPERATURE_DATAPOINT = "current_temperature_datapoint"
+CONF_TARGET_TEMPERATURE_DATAPOINT = "target_temperature_datapoint"
+CONF_TARGET_TEMPERATURE_LOW_DATAPOINT = "target_temperature_low_datapoint"
+CONF_TARGET_TEMPERATURE_HIGH_DATAPOINT = "target_temperature_high_datapoint"
+CONF_MODE_DATAPOINT = "mode_datapoint"
+CONF_CUSTOM_PRESET_DATAPOINT = "custom_preset_datapoint"
+CONF_CUSTOM_FAN_MODE_DATAPOINT = "custom_fan_mode_datapoint"
+CONF_MODES = "modes"
+CONF_CUSTOM_PRESETS = "custom_presets"
+CONF_CUSTOM_FAN_MODES = "custom_fan_modes"
+
 EconetClimate = econet_ns.class_(
     "EconetClimate", climate.Climate, cg.Component, EconetClient
 )
+
+
+def ensure_climate_mode_map(value):
+    cv.check_not_templatable(value)
+    options_map_schema = cv.Schema({cv.uint8_t: climate.validate_climate_mode})
+    value = options_map_schema(value)
+    all_values = list(value.keys())
+    unique_values = set(value.keys())
+    if len(all_values) != len(unique_values):
+        raise cv.Invalid("Mapping values must be unique.")
+    return value
+
+
+def ensure_option_map(value):
+    cv.check_not_templatable(value)
+    options_map_schema = cv.Schema({cv.uint8_t: cv.string_strict})
+    value = options_map_schema(value)
+    all_values = list(value.keys())
+    unique_values = set(value.keys())
+    if len(all_values) != len(unique_values):
+        raise cv.Invalid("Mapping values must be unique.")
+    return value
+
 
 CONFIG_SCHEMA = cv.All(
     climate.CLIMATE_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(EconetClimate),
+            cv.Optional(CONF_CURRENT_TEMPERATURE_DATAPOINT, default=""): cv.string,
+            cv.Optional(CONF_TARGET_TEMPERATURE_DATAPOINT, default=""): cv.string,
+            cv.Optional(CONF_TARGET_TEMPERATURE_LOW_DATAPOINT, default=""): cv.string,
+            cv.Optional(CONF_TARGET_TEMPERATURE_HIGH_DATAPOINT, default=""): cv.string,
+            cv.Optional(CONF_MODE_DATAPOINT, default=""): cv.string,
+            cv.Optional(CONF_CUSTOM_PRESET_DATAPOINT, default=""): cv.string,
+            cv.Optional(CONF_CUSTOM_FAN_MODE_DATAPOINT, default=""): cv.string,
+            cv.Optional(CONF_MODES, default={}): ensure_climate_mode_map,
+            cv.Optional(CONF_CUSTOM_PRESETS, default={}): ensure_option_map,
+            cv.Optional(CONF_CUSTOM_FAN_MODES, default={}): ensure_option_map,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -38,3 +82,34 @@ async def to_code(config):
     cg.add(var.set_econet_parent(paren))
     cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))
     cg.add(var.set_request_once(config[CONF_REQUEST_ONCE]))
+    cg.add(var.set_current_temperature_id(config[CONF_CURRENT_TEMPERATURE_DATAPOINT]))
+    cg.add(var.set_target_temperature_id(config[CONF_TARGET_TEMPERATURE_DATAPOINT]))
+    cg.add(
+        var.set_target_temperature_low_id(config[CONF_TARGET_TEMPERATURE_LOW_DATAPOINT])
+    )
+    cg.add(
+        var.set_target_temperature_high_id(
+            config[CONF_TARGET_TEMPERATURE_HIGH_DATAPOINT]
+        )
+    )
+    cg.add(var.set_mode_id(config[CONF_MODE_DATAPOINT]))
+    cg.add(var.set_custom_preset_id(config[CONF_CUSTOM_PRESET_DATAPOINT]))
+    cg.add(var.set_custom_fan_mode_id(config[CONF_CUSTOM_FAN_MODE_DATAPOINT]))
+    cg.add(
+        var.set_modes(
+            list(config[CONF_MODES].keys()),
+            list(config[CONF_MODES].values()),
+        )
+    )
+    cg.add(
+        var.set_custom_presets(
+            list(config[CONF_CUSTOM_PRESETS].keys()),
+            list(config[CONF_CUSTOM_PRESETS].values()),
+        )
+    )
+    cg.add(
+        var.set_custom_fan_modes(
+            list(config[CONF_CUSTOM_FAN_MODES].keys()),
+            list(config[CONF_CUSTOM_FAN_MODES].values()),
+        )
+    )

--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -15,280 +15,141 @@ namespace {
 float fahrenheit_to_celsius(float f) { return (f - 32) * 5 / 9; }
 float celsius_to_fahrenheit(float c) { return c * 9 / 5 + 32; }
 
+template<class K, class V> std::set<V> map_values_as_set(std::map<K, V> map) {
+  std::set<V> v;
+  std::transform(map.begin(), map.end(), std::inserter(v, v.end()), [](const std::pair<K, V> &p) { return p.second; });
+  return v;
+}
+
 }  // namespace
 
 static const char *const TAG = "econet.climate";
 
 void EconetClimate::dump_config() {
   LOG_CLIMATE("", "Econet Climate", this);
-  this->dump_traits_(TAG);
+  dump_traits_(TAG);
 }
 
 climate::ClimateTraits EconetClimate::traits() {
-  ModelType model_type = this->parent_->get_model_type();
   auto traits = climate::ClimateTraits();
-
-  traits.set_supports_action(false);
-
-  if (model_type == MODEL_TYPE_HVAC) {
-    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT,
-                                climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_FAN_ONLY});
-  } else {
-    traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_AUTO});
+  traits.set_supports_current_temperature(!current_temperature_id_.empty());
+  traits.set_supports_two_point_target_temperature(!target_temperature_high_id_.empty());
+  if (!mode_id_.empty()) {
+    traits.set_supported_modes(map_values_as_set(modes_));
   }
-
-  if (model_type == MODEL_TYPE_HEATPUMP) {
-    traits.set_supported_custom_presets({"Off", "Eco Mode", "Heat Pump", "High Demand", "Electric", "Vacation"});
-  } else if (model_type == MODEL_TYPE_ELECTRIC_TANK) {
-    traits.set_supported_custom_presets({"Energy Saver", "Performance"});
+  if (!custom_preset_id_.empty()) {
+    traits.set_supported_custom_presets(map_values_as_set(custom_presets_));
   }
-  traits.set_supports_current_temperature(true);
-  if (model_type == MODEL_TYPE_HVAC) {
-    traits.set_supported_custom_fan_modes({"Automatic", "Speed 1 (Low)", "Speed 2 (Medium Low)", "Speed 3 (Medium)",
-                                           "Speed 4 (Medium High)", "Speed 5 (High)"});
-
-    traits.set_supports_two_point_target_temperature(true);
-  } else {
-    traits.set_visual_min_temperature(43.3333);
-    traits.set_visual_max_temperature(60);
-
-    traits.set_supports_two_point_target_temperature(false);
+  if (!custom_fan_mode_id_.empty()) {
+    traits.set_supported_custom_fan_modes(map_values_as_set(custom_fan_modes_));
   }
-  traits.set_visual_temperature_step(1.0f);
-
   return traits;
 }
 
 void EconetClimate::setup() {
-  ModelType model_type = this->parent_->get_model_type();
-  if (model_type == MODEL_TYPE_HVAC) {
-    this->parent_->register_listener("HEATSETP", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       this->target_temperature_low = fahrenheit_to_celsius(datapoint.value_float);
-                                       this->publish_state();
-                                     });
-    this->parent_->register_listener("COOLSETP", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       this->target_temperature_high = fahrenheit_to_celsius(datapoint.value_float);
-                                       this->publish_state();
-                                     });
-    this->parent_->register_listener("SPT_STAT", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       this->current_temperature = fahrenheit_to_celsius(datapoint.value_float);
-                                       this->publish_state();
-                                     });
-  } else {
-    this->parent_->register_listener("WHTRSETP", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       this->target_temperature = fahrenheit_to_celsius(datapoint.value_float);
-                                       this->publish_state();
-                                     });
-    this->parent_->register_listener(
-        (model_type == MODEL_TYPE_HEATPUMP || model_type == MODEL_TYPE_ELECTRIC_TANK) ? "UPHTRTMP" : "TEMP_OUT",
-        this->request_mod_, this->request_once_, [this](const EconetDatapoint &datapoint) {
-          this->current_temperature = fahrenheit_to_celsius(datapoint.value_float);
-          this->publish_state();
-        });
+  if (!current_temperature_id_.empty()) {
+    parent_->register_listener(current_temperature_id_, request_mod_, request_once_,
+                               [this](const EconetDatapoint &datapoint) {
+                                 current_temperature = fahrenheit_to_celsius(datapoint.value_float);
+                                 publish_state();
+                               });
   }
-  if (model_type == MODEL_TYPE_HVAC) {
-    this->parent_->register_listener("STATMODE", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       switch (datapoint.value_enum) {
-                                         case 0:
-                                           this->mode = climate::CLIMATE_MODE_HEAT;
-                                           break;
-                                         case 1:
-                                           this->mode = climate::CLIMATE_MODE_COOL;
-                                           break;
-                                         case 2:
-                                           this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-                                           break;
-                                         case 3:
-                                           this->mode = climate::CLIMATE_MODE_FAN_ONLY;
-                                           break;
-                                         case 4:
-                                           this->mode = climate::CLIMATE_MODE_OFF;
-                                           break;
-                                       }
-                                       this->publish_state();
-                                     });
-    this->parent_->register_listener("STATNFAN", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       switch (datapoint.value_enum) {
-                                         case 0:
-                                           this->set_custom_fan_mode_("Automatic");
-                                           break;
-                                         case 1:
-                                           this->set_custom_fan_mode_("Speed 1 (Low)");
-                                           break;
-                                         case 2:
-                                           this->set_custom_fan_mode_("Speed 2 (Medium Low)");
-                                           break;
-                                         case 3:
-                                           this->set_custom_fan_mode_("Speed 3 (Medium)");
-                                           break;
-                                         case 4:
-                                           this->set_custom_fan_mode_("Speed 4 (Medium High)");
-                                           break;
-                                         case 5:
-                                           this->set_custom_fan_mode_("Speed 5 (High)");
-                                           break;
-                                       }
-                                       this->publish_state();
-                                     });
-  } else {
-    this->parent_->register_listener("WHTRENAB", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       if (datapoint.value_enum == 1) {
-                                         this->mode = climate::CLIMATE_MODE_AUTO;
-                                       } else {
-                                         this->mode = climate::CLIMATE_MODE_OFF;
-                                       }
-                                       this->publish_state();
-                                     });
+  if (!target_temperature_id_.empty()) {
+    parent_->register_listener(target_temperature_id_, request_mod_, request_once_,
+                               [this](const EconetDatapoint &datapoint) {
+                                 target_temperature = fahrenheit_to_celsius(datapoint.value_float);
+                                 publish_state();
+                               });
   }
-  if (model_type == MODEL_TYPE_HEATPUMP) {
-    this->parent_->register_listener("WHTRCNFG", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       switch (datapoint.value_enum) {
-                                         case 0:
-                                           this->set_custom_preset_("Off");
-                                           break;
-                                         case 1:
-                                           this->set_custom_preset_("Eco Mode");
-                                           break;
-                                         case 2:
-                                           this->set_custom_preset_("Heat Pump");
-                                           break;
-                                         case 3:
-                                           this->set_custom_preset_("High Demand");
-                                           break;
-                                         case 4:
-                                           this->set_custom_preset_("Electric");
-                                           break;
-                                         case 5:
-                                           this->set_custom_preset_("Vacation");
-                                           break;
-                                       }
-                                       this->publish_state();
-                                     });
-  } else if (model_type == MODEL_TYPE_ELECTRIC_TANK) {
-    this->parent_->register_listener("WHTRCNFG", this->request_mod_, this->request_once_,
-                                     [this](const EconetDatapoint &datapoint) {
-                                       switch (datapoint.value_enum) {
-                                         case 0:
-                                           this->set_custom_preset_("Energy Saver");
-                                           break;
-                                         case 1:
-                                           this->set_custom_preset_("Performance");
-                                           break;
-                                       }
-                                       this->publish_state();
-                                     });
+  if (!target_temperature_low_id_.empty()) {
+    parent_->register_listener(target_temperature_low_id_, request_mod_, request_once_,
+                               [this](const EconetDatapoint &datapoint) {
+                                 target_temperature_low = fahrenheit_to_celsius(datapoint.value_float);
+                                 publish_state();
+                               });
+  }
+  if (!target_temperature_high_id_.empty()) {
+    parent_->register_listener(target_temperature_high_id_, request_mod_, request_once_,
+                               [this](const EconetDatapoint &datapoint) {
+                                 target_temperature_high = fahrenheit_to_celsius(datapoint.value_float);
+                                 publish_state();
+                               });
+  }
+  if (!mode_id_.empty()) {
+    parent_->register_listener(mode_id_, request_mod_, request_once_, [this](const EconetDatapoint &datapoint) {
+      auto it = modes_.find(datapoint.value_enum);
+      if (it == modes_.end()) {
+        ESP_LOGW(TAG, "In modes of your yaml add a ClimateMode that corresponds to: %d: \"%s\"", datapoint.value_enum,
+                 datapoint.value_string.c_str());
+      } else {
+        mode = it->second;
+        publish_state();
+      }
+    });
+  }
+  if (!custom_preset_id_.empty()) {
+    parent_->register_listener(custom_preset_id_, request_mod_, request_once_,
+                               [this](const EconetDatapoint &datapoint) {
+                                 auto it = custom_presets_.find(datapoint.value_enum);
+                                 if (it == custom_presets_.end()) {
+                                   ESP_LOGW(TAG, "In custom_presets of your yaml add: %d: \"%s\"", datapoint.value_enum,
+                                            datapoint.value_string.c_str());
+                                 } else {
+                                   set_custom_preset_(it->second);
+                                   publish_state();
+                                 }
+                               });
+  }
+  if (!custom_fan_mode_id_.empty()) {
+    parent_->register_listener(custom_fan_mode_id_, request_mod_, request_once_,
+                               [this](const EconetDatapoint &datapoint) {
+                                 auto it = custom_fan_modes_.find(datapoint.value_enum);
+                                 if (it == custom_fan_modes_.end()) {
+                                   ESP_LOGW(TAG, "In custom_fan_modes of your yaml add: %d: \"%s\"",
+                                            datapoint.value_enum, datapoint.value_string.c_str());
+                                 } else {
+                                   set_custom_fan_mode_(it->second);
+                                   publish_state();
+                                 }
+                               });
   }
 }
 
 void EconetClimate::control(const climate::ClimateCall &call) {
-  ModelType model_type = this->parent_->get_model_type();
-  if (call.get_target_temperature_low().has_value()) {
-    this->parent_->set_float_datapoint_value("HEATSETP",
-                                             celsius_to_fahrenheit(call.get_target_temperature_low().value()));
+  if (call.get_target_temperature().has_value() && !target_temperature_id_.empty()) {
+    parent_->set_float_datapoint_value(target_temperature_id_,
+                                       celsius_to_fahrenheit(call.get_target_temperature().value()));
   }
-
-  if (call.get_target_temperature_high().has_value()) {
-    this->parent_->set_float_datapoint_value("COOLSETP",
-                                             celsius_to_fahrenheit(call.get_target_temperature_high().value()));
+  if (call.get_target_temperature_low().has_value() && !target_temperature_low_id_.empty()) {
+    parent_->set_float_datapoint_value(target_temperature_low_id_,
+                                       celsius_to_fahrenheit(call.get_target_temperature_low().value()));
   }
-
-  if (call.get_target_temperature().has_value()) {
-    this->parent_->set_float_datapoint_value("WHTRSETP", celsius_to_fahrenheit(call.get_target_temperature().value()));
+  if (call.get_target_temperature_high().has_value() && !target_temperature_high_id_.empty()) {
+    parent_->set_float_datapoint_value(target_temperature_high_id_,
+                                       celsius_to_fahrenheit(call.get_target_temperature_high().value()));
   }
-
-  if (call.get_mode().has_value()) {
-    climate::ClimateMode climate_mode = call.get_mode().value();
-    if (model_type == MODEL_TYPE_HVAC) {
-      uint8_t new_mode = 0;
-
-      switch (climate_mode) {
-        case climate::CLIMATE_MODE_HEAT_COOL:
-          new_mode = 2;
-          break;
-        case climate::CLIMATE_MODE_HEAT:
-          new_mode = 0;
-          break;
-        case climate::CLIMATE_MODE_COOL:
-          new_mode = 1;
-          break;
-        case climate::CLIMATE_MODE_FAN_ONLY:
-          new_mode = 3;
-          break;
-        case climate::CLIMATE_MODE_OFF:
-          new_mode = 4;
-          break;
-        default:
-          new_mode = 4;
-      }
-      ESP_LOGI("econet", "Raw Mode is %d", climate_mode);
-      ESP_LOGI("econet", "Lets change the mode to %d", new_mode);
-      this->parent_->set_enum_datapoint_value("STATMODE", new_mode);
-    } else {
-      bool new_mode = climate_mode != climate::CLIMATE_MODE_OFF;
-      ESP_LOGI("econet", "Raw Mode is %d", climate_mode);
-      ESP_LOGI("econet", "Lets change the mode to %d", new_mode);
-      this->parent_->set_enum_datapoint_value("WHTRENAB", new_mode);
+  if (call.get_mode().has_value() && !mode_id_.empty()) {
+    climate::ClimateMode mode = call.get_mode().value();
+    auto it = std::find_if(modes_.begin(), modes_.end(),
+                           [&mode](const std::pair<uint8_t, climate::ClimateMode> &p) { return p.second == mode; });
+    if (it != modes_.end()) {
+      parent_->set_enum_datapoint_value(mode_id_, it->first);
     }
   }
-
-  if (call.get_custom_fan_mode().has_value()) {
-    const std::string &fan_mode = call.get_custom_fan_mode().value();
-    int new_fan_mode = 0;
-    if (fan_mode == "Automatic") {
-      new_fan_mode = 0;
-    } else if (fan_mode == "Speed 1 (Low)") {
-      new_fan_mode = 1;
-    } else if (fan_mode == "Speed 2 (Medium Low)") {
-      new_fan_mode = 2;
-    } else if (fan_mode == "Speed 3 (Medium)") {
-      new_fan_mode = 3;
-    } else if (fan_mode == "Speed 4 (Medium High)") {
-      new_fan_mode = 4;
-    } else if (fan_mode == "Speed 5 (High)") {
-      new_fan_mode = 5;
-    }
-    this->parent_->set_enum_datapoint_value("STATNFAN", new_fan_mode);
-  }
-
-  if (call.get_custom_preset().has_value()) {
+  if (call.get_custom_preset().has_value() && !custom_preset_id_.empty()) {
     const std::string &preset = call.get_custom_preset().value();
-
-    ESP_LOGI("econet", "Set custom preset: %s", preset.c_str());
-
-    int8_t new_mode = -1;
-
-    if (model_type == MODEL_TYPE_HEATPUMP) {
-      if (preset == "Off") {
-        new_mode = 0;
-      } else if (preset == "Eco Mode") {
-        new_mode = 1;
-      } else if (preset == "Heat Pump") {
-        new_mode = 2;
-      } else if (preset == "High Demand") {
-        new_mode = 3;
-      } else if (preset == "Electric") {
-        new_mode = 4;
-      } else if (preset == "Vacation") {
-        new_mode = 5;
-      }
-    } else if (model_type == MODEL_TYPE_ELECTRIC_TANK) {
-      if (preset == "Energy Saver") {
-        new_mode = 0;
-      } else if (preset == "Performance") {
-        new_mode = 1;
-      }
+    auto it = std::find_if(custom_presets_.begin(), custom_presets_.end(),
+                           [&preset](const std::pair<uint8_t, std::string> &p) { return p.second == preset; });
+    if (it != custom_presets_.end()) {
+      parent_->set_enum_datapoint_value(custom_preset_id_, it->first);
     }
-
-    if (new_mode != -1) {
-      this->parent_->set_enum_datapoint_value("WHTRCNFG", new_mode);
+  }
+  if (call.get_custom_fan_mode().has_value() && !custom_fan_mode_id_.empty()) {
+    const std::string &fan_mode = call.get_custom_fan_mode().value();
+    auto it = std::find_if(custom_fan_modes_.begin(), custom_fan_modes_.end(),
+                           [&fan_mode](const std::pair<uint8_t, std::string> &p) { return p.second == fan_mode; });
+    if (it != custom_fan_modes_.end()) {
+      parent_->set_enum_datapoint_value(custom_fan_mode_id_, it->first);
     }
   }
 }

--- a/components/econet/climate/econet_climate.h
+++ b/components/econet/climate/econet_climate.h
@@ -11,8 +11,45 @@ class EconetClimate : public climate::Climate, public Component, public EconetCl
  public:
   void setup() override;
   void dump_config() override;
+  void set_current_temperature_id(const std::string &current_temperature_id) {
+    current_temperature_id_ = current_temperature_id;
+  }
+  void set_target_temperature_id(const std::string &target_temperature_id) {
+    target_temperature_id_ = target_temperature_id;
+  }
+  void set_target_temperature_low_id(const std::string &target_temperature_low_id) {
+    target_temperature_low_id_ = target_temperature_low_id;
+  }
+  void set_target_temperature_high_id(const std::string &target_temperature_high_id) {
+    target_temperature_high_id_ = target_temperature_high_id;
+  }
+  void set_mode_id(const std::string &mode_id) { mode_id_ = mode_id; }
+  void set_custom_preset_id(const std::string &custom_preset_id) { custom_preset_id_ = custom_preset_id; }
+  void set_custom_fan_mode_id(const std::string &custom_fan_mode_id) { custom_fan_mode_id_ = custom_fan_mode_id; }
+  void set_modes(const std::vector<uint8_t> &keys, const std::vector<climate::ClimateMode> &values) {
+    std::transform(keys.begin(), keys.end(), values.begin(), std::inserter(modes_, modes_.end()),
+                   [](uint8_t k, climate::ClimateMode v) { return std::make_pair(k, v); });
+  }
+  void set_custom_presets(const std::vector<uint8_t> &keys, const std::vector<std::string> &values) {
+    std::transform(keys.begin(), keys.end(), values.begin(), std::inserter(custom_presets_, custom_presets_.end()),
+                   [](uint8_t k, std::string v) { return std::make_pair(k, v); });
+  }
+  void set_custom_fan_modes(const std::vector<uint8_t> &keys, const std::vector<std::string> &values) {
+    std::transform(keys.begin(), keys.end(), values.begin(), std::inserter(custom_fan_modes_, custom_fan_modes_.end()),
+                   [](uint8_t k, std::string v) { return std::make_pair(k, v); });
+  }
 
  protected:
+  std::string current_temperature_id_{""};
+  std::string target_temperature_id_{""};
+  std::string target_temperature_low_id_{""};
+  std::string target_temperature_high_id_{""};
+  std::string mode_id_{""};
+  std::string custom_preset_id_{""};
+  std::string custom_fan_mode_id_{""};
+  std::map<uint8_t, climate::ClimateMode> modes_;
+  std::map<uint8_t, std::string> custom_presets_;
+  std::map<uint8_t, std::string> custom_fan_modes_;
   void control(const climate::ClimateCall &call) override;
   climate::ClimateTraits traits() override;
 };

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -8,12 +8,6 @@ static const char *const TAG = "econet";
 static const uint32_t RECEIVE_TIMEOUT = 100;
 static const uint32_t REQUEST_DELAY = 100;
 
-static const uint32_t WIFI_MODULE = 0x340;
-static const uint32_t SMARTEC_TRANSLATOR = 0x1040;
-static const uint32_t HEAT_PUMP_WATER_HEATER = 0x1280;
-static const uint32_t ELECTRIC_TANK_WATER_HEATER = 0x1200;
-static const uint32_t CONTROL_CENTER = 0x380;
-
 static const uint8_t DST_ADR_POS = 0;
 static const uint8_t SRC_ADR_POS = 5;
 static const uint8_t LEN_POS = 10;
@@ -152,7 +146,6 @@ std::string trim_trailing_whitespace(const char *p, uint8_t len) {
 
 void Econet::dump_config() {
   ESP_LOGCONFIG(TAG, "Econet:");
-  this->check_uart_settings(38400);
   for (auto &kv : this->datapoints_) {
     switch (kv.second.type) {
       case EconetDatapointType::FLOAT:
@@ -175,30 +168,14 @@ void Econet::dump_config() {
 
 // Makes one request: either the first pending write request or a new read request.
 void Econet::make_request_() {
-  // Use the address learned from a previous WRITE_COMMAND if possible.
-  uint32_t dst_adr = this->dst_adr_;
-  if (!dst_adr) {
-    if (model_type_ == MODEL_TYPE_HEATPUMP) {
-      dst_adr = HEAT_PUMP_WATER_HEATER;
-    } else if (model_type_ == MODEL_TYPE_ELECTRIC_TANK) {
-      dst_adr = ELECTRIC_TANK_WATER_HEATER;
-    } else if (model_type_ == MODEL_TYPE_HVAC) {
-      dst_adr = CONTROL_CENTER;
-    } else {
-      dst_adr = SMARTEC_TRANSLATOR;
-    }
-  }
-
-  uint32_t src_adr = WIFI_MODULE;
-
   if (!pending_writes_.empty()) {
     const auto &kv = pending_writes_.begin();
     switch (kv->second.type) {
       case EconetDatapointType::FLOAT:
-        this->write_value_(dst_adr, src_adr, kv->first, EconetDatapointType::FLOAT, kv->second.value_float);
+        this->write_value_(kv->first, EconetDatapointType::FLOAT, kv->second.value_float);
         break;
       case EconetDatapointType::ENUM_TEXT:
-        this->write_value_(dst_adr, src_adr, kv->first, EconetDatapointType::ENUM_TEXT, kv->second.value_enum);
+        this->write_value_(kv->first, EconetDatapointType::ENUM_TEXT, kv->second.value_enum);
         break;
       case EconetDatapointType::TEXT:
       case EconetDatapointType::RAW:
@@ -209,7 +186,7 @@ void Econet::make_request_() {
     return;
   }
 
-  request_strings_(dst_adr, src_adr);
+  request_strings_();
 }
 
 void Econet::parse_tx_message_() { this->parse_message_(true); }
@@ -412,8 +389,7 @@ void Econet::loop() {
   }
 }
 
-void Econet::write_value_(uint32_t dst_adr, uint32_t src_adr, const std::string &object, EconetDatapointType type,
-                          float value) {
+void Econet::write_value_(const std::string &object, EconetDatapointType type, float value) {
   std::vector<uint8_t> data;
 
   data.push_back(1);
@@ -434,10 +410,10 @@ void Econet::write_value_(uint32_t dst_adr, uint32_t src_adr, const std::string 
   data.push_back((uint8_t) (f_to_32 >> 8));
   data.push_back((uint8_t) (f_to_32));
 
-  transmit_message_(dst_adr, src_adr, WRITE_COMMAND, data);
+  transmit_message_(WRITE_COMMAND, data);
 }
 
-void Econet::request_strings_(uint32_t dst_adr, uint32_t src_adr) {
+void Econet::request_strings_() {
   uint8_t request_mod = read_requests_++ % request_mods_;
   std::vector<std::string> objects(request_datapoint_ids_[request_mod].begin(),
                                    request_datapoint_ids_[request_mod].end());
@@ -467,14 +443,14 @@ void Econet::request_strings_(uint32_t dst_adr, uint32_t src_adr) {
 
   join_obj_names(objects, &data);
 
-  transmit_message_(dst_adr, src_adr, READ_COMMAND, data);
+  transmit_message_(READ_COMMAND, data);
 }
 
-void Econet::transmit_message_(uint32_t dst_adr, uint32_t src_adr, uint8_t command, const std::vector<uint8_t> &data) {
+void Econet::transmit_message_(uint8_t command, const std::vector<uint8_t> &data) {
   tx_message_.clear();
 
-  address_to_bytes(dst_adr, &tx_message_);
-  address_to_bytes(src_adr, &tx_message_);
+  address_to_bytes(dst_adr_, &tx_message_);
+  address_to_bytes(src_adr_, &tx_message_);
 
   tx_message_.push_back(data.size());
   tx_message_.push_back(0);

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -10,8 +10,6 @@
 namespace esphome {
 namespace econet {
 
-enum ModelType { MODEL_TYPE_TANKLESS = 0, MODEL_TYPE_HEATPUMP = 1, MODEL_TYPE_HVAC = 2, MODEL_TYPE_ELECTRIC_TANK = 3 };
-
 class ReadRequest {
  public:
   uint32_t dst_adr;
@@ -68,9 +66,8 @@ class Econet : public Component, public uart::UARTDevice {
  public:
   void loop() override;
   void dump_config() override;
-
-  void set_model_type(ModelType model_type) { model_type_ = model_type; }
-  ModelType get_model_type() { return model_type_; }
+  void set_src_address(uint32_t address) { src_adr_ = address; }
+  void set_dst_address(uint32_t address) { dst_adr_ = address; }
 
   void set_update_interval(uint32_t interval_millis) { update_interval_millis_ = interval_millis; }
 
@@ -81,7 +78,6 @@ class Econet : public Component, public uart::UARTDevice {
                          const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint = false);
 
  protected:
-  ModelType model_type_;
   uint32_t update_interval_millis_{30000};
   std::vector<EconetDatapointListener> listeners_;
   ReadRequest read_req_;
@@ -95,10 +91,9 @@ class Econet : public Component, public uart::UARTDevice {
   void parse_tx_message_();
   void handle_response_(const std::string &datapoint_id, EconetDatapointType item_type, const uint8_t *p, uint8_t len);
 
-  void transmit_message_(uint32_t dst_adr, uint32_t src_adr, uint8_t command, const std::vector<uint8_t> &data);
-  void request_strings_(uint32_t dst_adr, uint32_t src_adr);
-  void write_value_(uint32_t dst_adr, uint32_t src_adr, const std::string &object, EconetDatapointType type,
-                    float value);
+  void transmit_message_(uint8_t command, const std::vector<uint8_t> &data);
+  void request_strings_();
+  void write_value_(const std::string &object, EconetDatapointType type, float value);
 
   std::vector<std::set<std::string>> request_datapoint_ids_ = std::vector<std::set<std::string>>(8);
   uint8_t request_mods_{1};
@@ -113,6 +108,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::vector<uint8_t> rx_message_;
   std::vector<uint8_t> tx_message_;
 
+  uint32_t src_adr_{0};
   uint32_t dst_adr_{0};
 };
 

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -21,7 +21,7 @@ esphome:
   board: $board
   project:
     name: "esphome-econet.esphome-econet"
-    version: 1.1.0
+    version: 1.2.0
 
 preferences:
   flash_write_interval: "24h"

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -53,6 +53,7 @@ uart:
 econet:
   uart_id: uart_0
   update_interval: ${econet_update_interval}
+  src_address: 0x340
 
 sensor:
   - platform: econet

--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -12,7 +12,7 @@ dashboard_import:
   import_full_config: false
 
 econet:
-  model: "Electric Tank"
+  dst_address: 0x1200
 
 climate:
   - platform: econet
@@ -21,6 +21,16 @@ climate:
       min_temperature: "43.3333"
       max_temperature: "60"
       temperature_step: 1.0f
+    current_temperature_datapoint: UPHTRTMP
+    target_temperature_datapoint: WHTRSETP
+    mode_datapoint: WHTRENAB
+    modes:
+      0: "OFF"
+      1: "AUTO"
+    custom_preset_datapoint: WHTRCNFG
+    custom_presets:
+      0: "Energy Saver"
+      1: "Performance"
 
 sensor:
   - platform: econet

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -76,7 +76,6 @@ sensor:
     accuracy_decimals: 3
     device_class: "power"
     state_class: "measurement"
-    entity_category: "diagnostic"
     filters:
       - lambda: ${sensor_power_filters_lambda}
   - platform: econet

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -13,7 +13,7 @@ dashboard_import:
   import_full_config: false
 
 econet:
-  model: "Heatpump"
+  dst_address: 0x1280
 
 climate:
   - platform: econet
@@ -22,6 +22,20 @@ climate:
       min_temperature: "43.3333"
       max_temperature: "60"
       temperature_step: 1.0f
+    current_temperature_datapoint: UPHTRTMP
+    target_temperature_datapoint: WHTRSETP
+    mode_datapoint: WHTRENAB
+    modes:
+      0: "OFF"
+      1: "AUTO"
+    custom_preset_datapoint: WHTRCNFG
+    custom_presets:
+      0: "Off"
+      1: "Eco Mode"
+      2: "Heat Pump"
+      3: "High Demand"
+      4: "Electric"
+      5: "Vacation"
 
 sensor:
   - platform: econet

--- a/econet_hvac.yaml
+++ b/econet_hvac.yaml
@@ -12,7 +12,7 @@ dashboard_import:
   import_full_config: false
 
 econet:
-  model: "HVAC"
+  dst_address: 0x380
   on_datapoint_update:
     - sensor_datapoint: AIRHSTAT
       datapoint_type: raw
@@ -31,6 +31,24 @@ climate:
       min_temperature: "10"
       max_temperature: "32.2222"
       temperature_step: 1.0f
+    current_temperature_datapoint: SPT_STAT
+    target_temperature_low_datapoint: HEATSETP
+    target_temperature_high_datapoint: COOLSETP
+    mode_datapoint: STATMODE
+    modes:
+      0: "HEAT"
+      1: "COOL"
+      2: "HEAT_COOL"
+      3: "FAN_ONLY"
+      4: "OFF"
+    custom_fan_mode_datapoint: STATNFAN
+    custom_fan_modes:
+      0: "Automatic"
+      1: "Speed 1 (Low)"
+      2: "Speed 2 (Medium Low)"
+      3: "Speed 3 (Medium)"
+      4: "Speed 4 (Medium High)"
+      5: "Speed 5 (High)"
 
 sensor:
   - platform: econet

--- a/econet_tankless_water_heater.yaml
+++ b/econet_tankless_water_heater.yaml
@@ -12,7 +12,7 @@ dashboard_import:
   import_full_config: false
 
 econet:
-  model: "Tankless"
+  dst_address: 0x1040
 
 climate:
   - platform: econet
@@ -21,6 +21,12 @@ climate:
       min_temperature: "43.3333"
       max_temperature: "60"
       temperature_step: 1.0f
+    current_temperature_datapoint: TEMP_OUT
+    target_temperature_datapoint: WHTRSETP
+    mode_datapoint: WHTRENAB
+    modes:
+      0: "OFF"
+      1: "AUTO"
 
 sensor:
   - platform: econet


### PR DESCRIPTION
- Now the C++ code has no device specific configuration. All of it is in yaml. This simplifies the code especially in climate.cpp since it uses maps defined in yaml. Most importantly, support for any new devices (potentially even non Rheem devices that use the BACnet protocol) should only require yaml changes.
- Remove diagnostic from power entity
- Bump version