### PR TITLE
Wait for device to be ready after a write command

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -302,6 +302,7 @@ void Econet::parse_message_(bool is_tx) {
     this->dst_adr_ = src_adr;
 
     uint8_t type = pdata[0];
+    ready_ = type == 9;
     ESP_LOGI(TAG, "  ClssType: %d", type);
     if (type == 1 && pdata[1] == 1) {
       EconetDatapointType datatype = EconetDatapointType(pdata[2]);
@@ -401,6 +402,11 @@ void Econet::loop() {
   }
 
   if (now - this->last_request_ <= REQUEST_DELAY) {
+    return;
+  }
+
+  if (!ready_) {
+    ESP_LOGD(TAG, "Waiting to be ready after a write command");
     return;
   }
 

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -114,6 +114,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::vector<uint8_t> tx_message_;
 
   uint32_t dst_adr_{0};
+  bool ready_{true};
 };
 
 class EconetClient {


### PR DESCRIPTION
Fix bug where some writes or reads don't succeed.

Bug: if I lower the temperature two times within a couple of seconds, the 2nd doesn't work. e.g. if I start with 120 and lower it to 118 the screen on the device says 129. After a while HA also reports 128. From the logs I see the write request is made but no ACK with 0x01 as data. I see that for up to 10 seconds after a write the MCU refuses to answer any request.

After some testing it seems every 10 seconds 0x1280 sends to 0xf1 a write command with 09.01.00.00.12.80. Within that 10s time window there can only be 1 write request and any subsequent read or write request will fail and won't ACK until the next 09.01.00.00.12.80.
