### PR TITLE
Fix auto detection of dst address and remove unnecessary ready code

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -222,11 +222,7 @@ void Econet::parse_message_(bool is_tx) {
       read_req_.awaiting_res = false;
     }
   } else if (command == WRITE_COMMAND) {
-    // Update the address to use for subsequent requests.
-    this->dst_adr_ = src_adr;
-
     uint8_t type = pdata[0];
-    ready_ = type == 9;
     ESP_LOGI(TAG, "  ClssType: %d", type);
     if (type == 1 && pdata[1] == 1) {
       EconetDatapointType datatype = EconetDatapointType(pdata[2]);
@@ -242,6 +238,8 @@ void Econet::parse_message_(bool is_tx) {
     } else if (type == 7) {
       ESP_LOGI(TAG, "  DateTime: %04d/%02d/%02d %02d:%02d:%02d.%02d\n", pdata[9] | pdata[8] << 8, pdata[7], pdata[6],
                pdata[5], pdata[4], pdata[3], pdata[2]);
+    } else if (type == 9) {
+      this->dst_adr_ = src_adr;
     }
   }
 }
@@ -326,11 +324,6 @@ void Econet::loop() {
   }
 
   if (now - this->last_request_ <= REQUEST_DELAY) {
-    return;
-  }
-
-  if (!ready_) {
-    ESP_LOGD(TAG, "Waiting to be ready after a write command");
     return;
   }
 

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -110,7 +110,6 @@ class Econet : public Component, public uart::UARTDevice {
 
   uint32_t src_adr_{0};
   uint32_t dst_adr_{0};
-  bool ready_{true};
 };
 
 class EconetClient {

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -21,7 +21,7 @@ esphome:
   board: $board
   project:
     name: "esphome-econet.esphome-econet"
-    version: 1.2.0
+    version: 1.2.1
 
 preferences:
   flash_write_interval: "24h"


### PR DESCRIPTION
After our own writes from the ESP (with src address set to the wifi address), line 226 was executed and set the dst_adr_ for subsequent requests to the wifi address. That's why subsequent read and write requests were failing until we would get a write request of type 9 that would set the dst_adr_ back to the correct value.