### PR TITLE
Add ids to all non HVAC sensors

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -59,6 +59,7 @@ econet:
 sensor:
   - platform: econet
     name: "Active Alerts"
+    id: alarm_count
     sensor_datapoint: ALRMALRT
     request_mod: 1
     accuracy_decimals: 0
@@ -66,35 +67,41 @@ sensor:
     state_class: "measurement"
   - platform: wifi_signal
     name: "WiFi Signal Strength"
+    id: wifi_signal_sensor
     entity_category: "diagnostic"
 
 text_sensor:
   - platform: econet
     name: "Alarm 1"
+    id: alarm_1
     sensor_datapoint: ALARM_01
     request_mod: 1
     icon: "mdi:alert"
     entity_category: "diagnostic"
   - platform: econet
     name: "Alarm 2"
+    id: alarm_2
     sensor_datapoint: ALARM_02
     request_mod: 1
     icon: "mdi:alert"
     entity_category: "diagnostic"
   - platform: econet
     name: "Alarm 3"
+    id: alarm_3
     sensor_datapoint: ALARM_03
     request_mod: 1
     icon: "mdi:alert"
     entity_category: "diagnostic"
   - platform: econet
     name: "Alarm 4"
+    id: alarm_4
     sensor_datapoint: ALARM_04
     request_mod: 1
     icon: "mdi:alert"
     entity_category: "diagnostic"
   - platform: econet
     name: "Software Version Number"
+    id: sw_version
     sensor_datapoint: SW_VERSN
     request_mod: 2
     request_once: true
@@ -104,18 +111,21 @@ text_sensor:
 switch:
   - platform: econet
     name: "Beep On Alarm"
+    id: alarm_beep
     switch_datapoint: ALRMBEEP
     request_mod: 2
     icon: "mdi:alarm-note"
     entity_category: "config"
   - platform: econet
     name: "Screen Adjustment Lock"
+    id: screen_lock
     switch_datapoint: SCRNLOCK
     request_mod: 2
     icon: "mdi:gesture-tap-button"
     entity_category: "config"
   - platform: econet
     name: "Screen Unit in °C"
+    id: display_unit
     switch_datapoint: DISPUNIT
     request_mod: 2
     icon: "mdi:temperature-celsius"
@@ -134,10 +144,12 @@ switch:
 button:
   - platform: restart
     name: "Restart ESP"
+    id: restart_esp
     icon: "mdi:restart"
     entity_category: "config"
   - platform: template
     name: "Restart Microcontroller"
+    id: restart_mcu
     icon: "mdi:restart"
     entity_category: "config"
     on_press:
@@ -146,6 +158,7 @@ button:
       - switch.turn_off: resetdev
   - platform: template
     name: "Alarm Reset"
+    id: alarm_reset
     icon: "mdi:restart-alert"
     entity_category: "config"
     on_press:

--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -35,6 +35,7 @@ climate:
 sensor:
   - platform: econet
     name: "Lower Tank Temperature"
+    id: lower_tank_temp
     sensor_datapoint: LOHTRTMP
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -43,6 +44,7 @@ sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "Upper Tank Temperature"
+    id: upper_tank_temp
     sensor_datapoint: UPHTRTMP
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -53,9 +55,11 @@ sensor:
 text_sensor:
   - platform: econet
     name: "Heating Element State"
+    id: heating_element
     sensor_datapoint: HEATCTRL
     icon: "mdi:heating-coil"
   - platform: econet
     name: "Mode"
+    id: mode
     sensor_datapoint: WHTRMODE
     entity_category: "diagnostic"

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -40,6 +40,7 @@ climate:
 sensor:
   - platform: econet
     name: "Hot Water"
+    id: hot_water
     sensor_datapoint: HOTWATER
     unit_of_measurement: "%"
     accuracy_decimals: 0
@@ -47,6 +48,7 @@ sensor:
     state_class: "measurement"
   - platform: econet
     name: "Ambient Temperature"
+    id: ambient_temp
     sensor_datapoint: AMBIENTT
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -55,6 +57,7 @@ sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "Lower Tank Temperature"
+    id: lower_tank_temp
     sensor_datapoint: LOHTRTMP
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -63,6 +66,7 @@ sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "Upper Tank Temperature"
+    id: upper_tank_temp
     sensor_datapoint: UPHTRTMP
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -71,6 +75,7 @@ sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "Power"
+    id: power
     sensor_datapoint: POWRWATT
     unit_of_measurement: "W"
     accuracy_decimals: 3
@@ -80,6 +85,7 @@ sensor:
       - lambda: ${sensor_power_filters_lambda}
   - platform: econet
     name: "Evaporator Temperature"
+    id: evaporator_temp
     sensor_datapoint: EVAPTEMP
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -88,6 +94,7 @@ sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "Suction Temperature"
+    id: suction_temp
     sensor_datapoint: SUCTIONT
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -96,6 +103,7 @@ sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "Discharge Temperature"
+    id: discharge_temp
     sensor_datapoint: DISCTEMP
     unit_of_measurement: "°F"
     accuracy_decimals: 1
@@ -106,20 +114,24 @@ sensor:
 binary_sensor:
   - platform: econet
     name: "Compressor"
+    id: compressor
     sensor_datapoint: COMP_RLY
     device_class: "running"
 
 text_sensor:
   - platform: econet
     name: "Fan Speed"
+    id: fan_speed
     sensor_datapoint: FAN_CTRL
     icon: "mdi:fan"
   - platform: econet
     name: "Heating Element State"
+    id: heating_element
     sensor_datapoint: HEATCTRL
     icon: "mdi:heating-coil"
   - platform: econet
     name: "Model Number"
+    id: model_number
     sensor_datapoint: PRODMODN
     request_mod: 2
     request_once: true
@@ -127,6 +139,7 @@ text_sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "Serial Number"
+    id: serial_number
     sensor_datapoint: PRODSERN
     request_mod: 2
     request_once: true

--- a/econet_tankless_water_heater.yaml
+++ b/econet_tankless_water_heater.yaml
@@ -49,6 +49,7 @@ sensor:
     entity_category: "diagnostic"
   - platform: econet
     name: "BTUs Used"
+    id: btus
     sensor_datapoint: WTR_BTUS
     unit_of_measurement: "kbtu"
     accuracy_decimals: 3
@@ -56,6 +57,7 @@ sensor:
     icon: "mdi:flash"
   - platform: econet
     name: "Water Used"
+    id: water_used
     sensor_datapoint: WTR_USED
     unit_of_measurement: "gal"
     accuracy_decimals: 1
@@ -76,6 +78,7 @@ sensor:
     icon: "mdi:water"
   - platform: econet
     name: "Ignition Cycles"
+    id: ignition_cycles
     sensor_datapoint: IGNCYCLS
     unit_of_measurement: ""
     accuracy_decimals: 0
@@ -83,6 +86,7 @@ sensor:
     icon: "mdi:heating-coil"
   - platform: template
     name: "Instant BTUs"
+    id: instant_btus
     unit_of_measurement: "kbtu/hr"
     accuracy_decimals: 3
     state_class: "measurement"

--- a/example-esp32.yaml
+++ b/example-esp32.yaml
@@ -18,3 +18,13 @@ packages:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+
+# If you have an RS485-TTL module with flow control pin, such as MAX485,
+# wire DE and RE to GPIO0 and uncomment the following 2 lines:
+# econet:
+#   flow_control_pin: GPIO0
+
+# If you don't want to expose specific sensors to Home Assistant:
+# text_sensor:
+#   - id: !extend sw_version
+#     internal: true


### PR DESCRIPTION
This allows extending specific sensors to change their settings while still using the package. For example sensor_power_filters_lambda is now redundant but I'm keeping it for backwards compatibility. Another example is to hide specific sensors from Home Assistant see https://github.com/esphome-econet/esphome-econet/discussions/131
Add an example how to use the `!extend`.
Also add an example how to configure the `flow_control_pin` since someone at discord misplaced it.