### PR TITLE
Adding markdownlint-cli2 to pre-commit config

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+---
+# Default state for all rules
+default: true
+
+MD013: false  # Disable line-length checking
+MD033:
+  allowed_elements: [img]  # Allow embedded image tags as there is no way to resize images in native markdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,7 @@ repos:
     rev: v1.32.0
     hooks:
       - id: yamllint
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.10.0
+    hooks:
+      - id: markdownlint-cli2


### PR DESCRIPTION
I've added markdown linting and ran (and addressed) all issues reported by `pre-commit run --all-files`