### PR TITLE
Moving minimum esphome version to 2023.8.0

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   comment: ${device_description}
-  min_version: "2023.2.0"
+  min_version: "2023.8.0" # This version introduced crc16 helper functions which are now used by esphome-econet
   platform: $platform
   board: $board
   project:


### PR DESCRIPTION
It looks like https://github.com/esphome-econet/esphome-econet/pull/110 leverages esphome helper functions added in late July. As a result, building with older esphome versions fails.