### PR TITLE
Initial workflow for publishing of pre-built firmware

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
       - name: Build manifest
         uses: mikefarah/yq@v4.35.2
         with:
@@ -46,7 +46,7 @@ jobs:
           mkdir output
           mv ${{ steps.esphome-build.outputs.name }} output/
       - name: Upload artifact
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}
           path: output
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Download built firmwares
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           path: firmwares
       - name: Dump Files
@@ -84,7 +84,7 @@ jobs:
         run: |-
           jq -s '{"name": "esphome-econet", "new_install_improv_wait_time": 15, "new_install_prompt_erase": true, "version": "", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' firmwares/*/econet-${{ matrix.appliance.shorthand }}-*/manifest.json > output/econet-${{ matrix.appliance.shorthand }}.json
       - name: Upload artifact
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: econet-${{ matrix.appliance.shorthand }}
           path: output
@@ -97,9 +97,9 @@ jobs:
     needs: consolidate-manifests
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
       - name: Download built firmwares
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           path: firmwares
       - name: Dump Files
@@ -111,7 +111,7 @@ jobs:
           cp -R firmwares/*/* output/
           ls -R output/
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v1.0.7
+        uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: output
 
@@ -128,7 +128,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3.0.6
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1.2.3
+        uses: actions/deploy-pages@v2.0.4

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -50,7 +50,6 @@ jobs:
           retention-days: 7
 
   consolidate-manifests:
-    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     name: Consolidate ${{ matrix.appliance.shorthand }} manifests
     runs-on: ubuntu-latest
     needs: build
@@ -88,7 +87,6 @@ jobs:
           retention-days: 7
 
   consolidate:
-    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     name: Consolidate firmwares
     runs-on: ubuntu-latest
     needs: consolidate-manifests
@@ -113,7 +111,6 @@ jobs:
           path: output
 
   deploy:
-    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: consolidate

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,11 +1,8 @@
 ---
 name: Build and Publish
 
-# Based on https://github.com/esphome/firmware/blob/main/.github/workflows/build.yml
-
 on:
   workflow_dispatch:
-  push: # TODO: Remove after testing
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -82,7 +79,7 @@ jobs:
           mkdir output
       - name: Consolidate manifests
         run: |-
-          jq -s '{"name": "esphome-econet", "new_install_improv_wait_time": 15, "new_install_prompt_erase": true, "version": "", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' firmwares/*/econet-${{ matrix.appliance.shorthand }}-*/manifest.json > output/econet-${{ matrix.appliance.shorthand }}.json
+          jq -s '{"name": "esphome-econet", "new_install_improv_wait_time": 15, "new_install_prompt_erase": false, "version": "", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' firmwares/*/econet-${{ matrix.appliance.shorthand }}-*/manifest.json > output/econet-${{ matrix.appliance.shorthand }}.json
       - name: Upload artifact
         uses: actions/upload-artifact@v3.1.3
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,134 @@
+---
+name: Build and Publish
+
+# Based on https://github.com/esphome/firmware/blob/main/.github/workflows/build.yml
+
+on:
+  workflow_dispatch:
+  push: # TODO: Remove after testing
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [esp32, esp8266]
+        appliance:
+          - name: electric_tank_water_heater
+            shorthand: etwh
+          - name: heatpump_water_heater
+            shorthand: hpwh
+          - name: hvac
+            shorthand: hvac
+          - name: tankless_water_heater
+            shorthand: tlwh
+      fail-fast: false
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Build manifest
+        uses: mikefarah/yq@v4.35.2
+        with:
+          cmd: yq -P '.packages.econet = "econet_${{ matrix.appliance.name }}.yaml" | .packages.econet   tag = "!include"' ./build-yaml/${{ matrix.platform }}.yaml > econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
+      - name: Build firmware
+        uses: esphome/build-action@v1.8.0
+        id: esphome-build
+        with:
+          yaml_file: econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
+          version: latest
+      - name: Copy firmware and manifest
+        run: |
+          mkdir output
+          mv ${{ steps.esphome-build.outputs.name }} output/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}
+          path: output
+          retention-days: 7
+
+  consolidate-manifests:
+    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    name: Consolidate ${{ matrix.appliance.shorthand }} manifests
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        appliance:
+          - name: electric_tank_water_heater
+            shorthand: etwh
+          - name: heatpump_water_heater
+            shorthand: hpwh
+          - name: hvac
+            shorthand: hvac
+          - name: tankless_water_heater
+            shorthand: tlwh
+      fail-fast: false
+    steps:
+      - name: Download built firmwares
+        uses: actions/download-artifact@v3
+        with:
+          path: firmwares
+      - name: Dump Files
+        run: |-
+          ls -R firmwares
+      - name: Copy files
+        run: |-
+          mkdir output
+      - name: Consolidate manifests
+        run: |-
+          jq -s '{"name": "esphome-econet", "new_install_improv_wait_time": 15, "new_install_prompt_erase": true, "version": "", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' firmwares/*/econet-${{ matrix.appliance.shorthand }}-*/manifest.json > output/econet-${{ matrix.appliance.shorthand }}.json
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: econet-${{ matrix.appliance.shorthand }}
+          path: output
+          retention-days: 7
+
+  consolidate:
+    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    name: Consolidate firmwares
+    runs-on: ubuntu-latest
+    needs: consolidate-manifests
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Download built firmwares
+        uses: actions/download-artifact@v3
+        with:
+          path: firmwares
+      - name: Dump Files
+        run: |-
+          ls -R firmwares
+      - name: Copy files
+        run: |-
+          mkdir output
+          cp -R firmwares/*/* output/
+          ls -R output/
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1.0.7
+        with:
+          path: output
+
+  deploy:
+    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: consolidate
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1.2.3

--- a/build-yaml/esp32.yaml
+++ b/build-yaml/esp32.yaml
@@ -1,0 +1,9 @@
+---
+substitutions:
+  tx_pin: GPIO19
+  rx_pin: GPIO22
+  platform: esp32
+  board: esp32dev
+
+wifi:
+  ap:

--- a/build-yaml/esp8266.yaml
+++ b/build-yaml/esp8266.yaml
@@ -1,0 +1,9 @@
+---
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+  platform: esp8266
+  board: d1_mini
+
+wifi:
+  ap:


### PR DESCRIPTION
This is an initial implementation of a flow to pre-build and publish builds to Github Pages to allow us to host an ESP Tools website. I have tested this successfully using my own Github Pages site.

In the future, I will likely have this trigger off of any new release but for now we can run it manually.