### PR TITLE
Adding improv_serial to configs for web-based installation firmware.

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -80,7 +80,7 @@ jobs:
           mkdir output
       - name: Consolidate manifests
         run: |-
-          jq -s '{"name": "esphome-econet", "new_install_improv_wait_time": 15, "new_install_prompt_erase": false, "version": "${{ github.ref_name }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' firmwares/*/econet-${{ matrix.appliance.shorthand }}-*/manifest.json > output/econet-${{ matrix.appliance.shorthand }}.json
+          jq -s '{"name": "esphome-econet", "new_install_improv_wait_time": 15, "new_install_prompt_erase": false, "version": "${{ github.ref_name }}", "home_assistant_domain": "esphome", "builds":.}' firmwares/*/econet-${{ matrix.appliance.shorthand }}-*/manifest.json > output/econet-${{ matrix.appliance.shorthand }}.json
       - name: Upload artifact
         uses: actions/upload-artifact@v3.1.3
         with:

--- a/build-yaml/esp32.yaml
+++ b/build-yaml/esp32.yaml
@@ -4,7 +4,6 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
-  uart_id: uart_1  # Need to free up UART_0 for the logger to enable improv_serial
 
 wifi:
   ap:
@@ -12,7 +11,6 @@ wifi:
 logger:
   baud_rate: 115200
   level: ${logger_level}
-  tx_buffer_size: 512
   hardware_uart: UART0
 
 improv_serial:

--- a/build-yaml/esp32.yaml
+++ b/build-yaml/esp32.yaml
@@ -4,6 +4,15 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  uart_id: uart_1
 
 wifi:
   ap:
+
+logger:
+  baud_rate: 115200  # Make sure logging is not using the serial port
+  level: ${logger_level}
+  tx_buffer_size: 512
+  hardware_uart: UART0
+
+improv_serial:

--- a/build-yaml/esp32.yaml
+++ b/build-yaml/esp32.yaml
@@ -4,13 +4,13 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
-  uart_id: uart_1
+  uart_id: uart_1  # Need to free up UART_0 for the logger to enable improv_serial
 
 wifi:
   ap:
 
 logger:
-  baud_rate: 115200  # Make sure logging is not using the serial port
+  baud_rate: 115200
   level: ${logger_level}
   tx_buffer_size: 512
   hardware_uart: UART0

--- a/build-yaml/esp8266.yaml
+++ b/build-yaml/esp8266.yaml
@@ -4,7 +4,6 @@ substitutions:
   rx_pin: GPIO5
   platform: esp8266
   board: d1_mini
-  uart_id: uart_1  # Need to free up UART_0 for the logger to enable improv_serial
 
 wifi:
   ap:
@@ -12,7 +11,6 @@ wifi:
 logger:
   baud_rate: 115200
   level: ${logger_level}
-  tx_buffer_size: 512
   hardware_uart: UART0
 
 improv_serial:

--- a/build-yaml/esp8266.yaml
+++ b/build-yaml/esp8266.yaml
@@ -4,6 +4,15 @@ substitutions:
   rx_pin: GPIO5
   platform: esp8266
   board: d1_mini
+  uart_id: uart_1
 
 wifi:
   ap:
+
+logger:
+  baud_rate: 115200  # Make sure logging is not using the serial port
+  level: ${logger_level}
+  tx_buffer_size: 512
+  hardware_uart: UART0
+
+improv_serial:

--- a/build-yaml/esp8266.yaml
+++ b/build-yaml/esp8266.yaml
@@ -4,13 +4,13 @@ substitutions:
   rx_pin: GPIO5
   platform: esp8266
   board: d1_mini
-  uart_id: uart_1
+  uart_id: uart_1  # Need to free up UART_0 for the logger to enable improv_serial
 
 wifi:
   ap:
 
 logger:
-  baud_rate: 115200  # Make sure logging is not using the serial port
+  baud_rate: 115200
   level: ${logger_level}
   tx_buffer_size: 512
   hardware_uart: UART0

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -11,7 +11,6 @@ substitutions:
   external_components_source: github://esphome-econet/esphome-econet@${github_ref}
   logger_level: WARN
   econet_update_interval: 30s
-  uart_id: uart_0
 
 esphome:
   name: ${name}
@@ -39,20 +38,19 @@ ota:
 logger:
   baud_rate: 0  # Make sure logging is not using the serial port
   level: ${logger_level}
-  tx_buffer_size: 2000
 
 external_components:
   - source: ${external_components_source}
 
 uart:
-  id: ${uart_id}
+  id: econet_uart
   baud_rate: 38400
   rx_buffer_size: 1500
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}
 
 econet:
-  uart_id: ${uart_id}
+  uart_id: econet_uart
   update_interval: ${econet_update_interval}
   src_address: 0x340
 


### PR DESCRIPTION
I've tested this via https://barndawgie.github.io/install/

There are two main caveats with this:

1. In theory, improv_serial should immediately connect after install to allow wi-fi configuration. In practice this fails and you need to hit "Connect" a second time to get the Configure Wi-Fi option. I believe this needs to be filed as an ESP Web Tools bug - will do that once we get this finalized and tested by a few more people.
2. improv relies on UART0 for communication, so esphome-econet needs to move to UART1. This is fine for esp32 devices, but could be a problem (and requires testing) with ESP8266 devices since this implies moving to software UART for communication with the Rheem appliance.