### PR TITLE
Making build workflow reusable.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,7 @@ name: Build Firmware
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  workflow_call:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Make build workflow callable by other workflows and stop running it after pushes (too late to catch things at that point).