### PR TITLE
Adding build-status step to give overall status of build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,3 +63,12 @@ jobs:
           name: econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}
           path: output
           retention-days: 7
+  build-status: # Needed to provide an overall status on this job rather than just the various matrix jobs
+    name: Compile Build Status
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.build.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
Adding a build-status check so that I can create a Branch Protection Rule requiring successful build before merge. See https://github.com/orgs/community/discussions/26822#discussioncomment-3253537 for example I used.