### PR TITLE
Add select component and vacation mode

### DIFF
--- a/components/econet/select/__init__.py
+++ b/components/econet/select/__init__.py
@@ -1,0 +1,55 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import select
+from esphome.const import CONF_OPTIONS, CONF_ENUM_DATAPOINT
+
+from .. import (
+    CONF_ECONET_ID,
+    CONF_REQUEST_MOD,
+    CONF_REQUEST_ONCE,
+    ECONET_CLIENT_SCHEMA,
+    EconetClient,
+    econet_ns,
+)
+
+DEPENDENCIES = ["econet"]
+
+EconetSelect = econet_ns.class_(
+    "EconetSelect", select.Select, cg.Component, EconetClient
+)
+
+
+def ensure_option_map(value):
+    cv.check_not_templatable(value)
+    options_map_schema = cv.Schema({cv.uint8_t: cv.string_strict})
+    value = options_map_schema(value)
+    all_values = list(value.keys())
+    unique_values = set(value.keys())
+    if len(all_values) != len(unique_values):
+        raise cv.Invalid("Mapping values must be unique.")
+    return value
+
+
+CONFIG_SCHEMA = (
+    select.select_schema(EconetSelect)
+    .extend(
+        {
+            cv.Required(CONF_ENUM_DATAPOINT): cv.string,
+            cv.Required(CONF_OPTIONS): ensure_option_map,
+        }
+    )
+    .extend(ECONET_CLIENT_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    options_map = config[CONF_OPTIONS]
+    var = await select.new_select(config, options=list(options_map.values()))
+    await cg.register_component(var, config)
+    cg.add(var.set_select_mappings(list(options_map.keys())))
+    paren = await cg.get_variable(config[CONF_ECONET_ID])
+    cg.add(var.set_econet_parent(paren))
+    cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))
+    cg.add(var.set_request_once(config[CONF_REQUEST_ONCE]))
+    cg.add(var.set_select_id(config[CONF_ENUM_DATAPOINT]))

--- a/components/econet/select/econet_select.cpp
+++ b/components/econet/select/econet_select.cpp
@@ -1,0 +1,48 @@
+#include "esphome/core/log.h"
+#include "econet_select.h"
+
+namespace esphome {
+namespace econet {
+
+static const char *const TAG = "econet.select";
+
+void EconetSelect::setup() {
+  this->parent_->register_listener(
+      this->select_id_, this->request_mod_, this->request_once_, [this](const EconetDatapoint &datapoint) {
+        uint8_t enum_value = datapoint.value_enum;
+        ESP_LOGV(TAG, "MCU reported select %s value %u", this->select_id_.c_str(), enum_value);
+        auto mappings = this->mappings_;
+        auto it = std::find(mappings.cbegin(), mappings.cend(), enum_value);
+        if (it == mappings.end()) {
+          ESP_LOGW(TAG, "Invalid value %u", enum_value);
+          return;
+        }
+        size_t mapping_idx = std::distance(mappings.cbegin(), it);
+        auto value = this->at(mapping_idx);
+        this->publish_state(value.value());
+      });
+}
+
+void EconetSelect::control(const std::string &value) {
+  auto idx = this->index_of(value);
+  if (idx.has_value()) {
+    uint8_t mapping = this->mappings_.at(idx.value());
+    ESP_LOGV(TAG, "Setting %s datapoint value to %u:%s", this->select_id_.c_str(), mapping, value.c_str());
+    this->parent_->set_enum_datapoint_value(this->select_id_, mapping);
+    return;
+  }
+  ESP_LOGW(TAG, "Invalid value %s", value.c_str());
+}
+
+void EconetSelect::dump_config() {
+  LOG_SELECT("", "Econet Select", this);
+  ESP_LOGCONFIG(TAG, "  Select has datapoint ID %s", this->select_id_.c_str());
+  ESP_LOGCONFIG(TAG, "  Options are:");
+  auto options = this->traits.get_options();
+  for (auto i = 0; i < this->mappings_.size(); i++) {
+    ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_.at(i), options.at(i).c_str());
+  }
+}
+
+}  // namespace econet
+}  // namespace esphome

--- a/components/econet/select/econet_select.h
+++ b/components/econet/select/econet_select.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/select/select.h"
+#include "../econet.h"
+
+#include <vector>
+
+namespace esphome {
+namespace econet {
+
+class EconetSelect : public select::Select, public Component, public EconetClient {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void set_select_id(const std::string &select_id) { this->select_id_ = select_id; }
+  void set_select_mappings(std::vector<uint8_t> mappings) { this->mappings_ = std::move(mappings); }
+
+ protected:
+  void control(const std::string &value) override;
+
+  std::string select_id_{""};
+  std::vector<uint8_t> mappings_;
+};
+
+}  // namespace econet
+}  // namespace esphome

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -21,7 +21,7 @@ esphome:
   board: $board
   project:
     name: "esphome-econet.esphome-econet"
-    version: 1.4.0
+    version: 1.4.2
 
 preferences:
   flash_write_interval: "24h"

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -31,7 +31,50 @@ climate:
       2: "Heat Pump"
       3: "High Demand"
       4: "Electric"
-      5: "Vacation"
+      # Vacation preset doesn't seem to have any effect
+      # 5: "Vacation"
+
+select:
+  - platform: "econet"
+    name: "Vacation Mode Setting"
+    id: vaca_net
+    enum_datapoint: VACA_NET
+    options:
+      0: "Off"
+      1: "Timed"
+      2: "Permanent"
+    icon: "mdi:bag-suitcase"
+    disabled_by_default: true
+
+switch:
+  - platform: template
+    name: "Vacation Mode"
+    id: vacation_mode
+    restore_mode: DISABLED
+    lambda: |-
+      return id(vaca_net).state != "Off";
+    turn_on_action:
+      - select.set:
+          id: vaca_net
+          option: "Permanent"
+    turn_off_action:
+      - select.set:
+          id: vaca_net
+          option: "Off"
+    icon: "mdi:bag-suitcase"
+
+number:
+  - platform: econet
+    name: "Vacation Timer"
+    number_datapoint: VACATIME
+    unit_of_measurement: "h"
+    step: 1
+    min_value: 1
+    max_value: 10000
+    mode: box
+    icon: "mdi:briefcase-clock"
+    entity_category: "config"
+    disabled_by_default: true
 
 sensor:
   - platform: econet


### PR DESCRIPTION
- The select component follows the Tuya Select see https://esphome.io/components/select/tuya.html and https://github.com/esphome/esphome/tree/dev/esphome/components/tuya/select
- Add disabled_by_default select for VACA_NET and number for VACATIME
- Expose a vacation switch that sets VACA_NET to 2 (Permanent)
- Comment out the Vacation preset since it doesn't seem to do anything

An alternative to this would have been:
```yaml
climate:
  - platform: econet
    name: None
    visual:
      min_temperature: "43.3333"
      max_temperature: "60"
      temperature_step: 1.0f
    current_temperature_datapoint: UPHTRTMP
    target_temperature_datapoint: WHTRSETP
    mode_datapoint: WHTRENAB
    modes:
      0: "OFF"
      1: "AUTO"
    custom_preset_datapoint: WHTRCNFG
    custom_presets:
      0: "Off"
      1: "Eco Mode"
      2: "Heat Pump"
      3: "High Demand"
      4: "Electric"
      5: "Vacation"
    on_control:
      - lambda: |-
          if (x.get_custom_preset().has_value()) {
            auto call = id(vaca_net).make_call();
            call.set_option(x.get_custom_preset().value() == "Vacation" ? "Permanent" : "Off");
            call.perform();
          }

select:
  - platform: "econet"
    name: "Vacation Mode Setting"
    id: vaca_net
    enum_datapoint: VACA_NET
    options:
      0: "Off"
      1: "Timed"
      2: "Permanent"
    icon: "mdi:bag-suitcase"
    disabled_by_default: true
```
With that as soon as the preset is set to Vacation we set VACA_NET to 2 but a side effect of setting VACA_NET to 2 is that WHTRCNFG changes from 5: Vacation to 1: Eco Mode.