### PR TITLE
Make runtime verbiage consistent between Upper and Lower Heating Elements

### DIFF
--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -59,7 +59,7 @@ sensor:
     filters:
       - lambda: ${sensor_power_filters_lambda}
   - platform: econet
-    name: "Lower Heater Runtime"
+    name: "Lower Heating Element Runtime"
     id: hours_lower_heater
     sensor_datapoint: HRSLOHTR
     unit_of_measurement: "h"

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -131,7 +131,7 @@ sensor:
     state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
-    name: "Lower Heater Runtime"
+    name: "Lower Heating Element Runtime"
     id: hours_lower_heater
     sensor_datapoint: HRSLOHTR
     unit_of_measurement: "h"


### PR DESCRIPTION
Changed the verbiage of the Lower Heating Element Runtime to make verbiage consistent between Upper and Lower Heating Elements.