### PR TITLE
Add update_interval to the gas template

### DIFF
--- a/econet_tankless_water_heater.yaml
+++ b/econet_tankless_water_heater.yaml
@@ -91,3 +91,4 @@ sensor:
     lambda: |-
       return max((id(temp_out).state - id(temp_in).state) * id(flow_rate).state * 8.334 * 60 / 0.92 / 1000, 0.0);
     # yamllint enable rule:line-length
+    update_interval: ${econet_update_interval}


### PR DESCRIPTION
By default this was updated every 60s. Change it to match the interval used for the underlying econet sensors.