### PR TITLE
Avoid truncating log messages

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -37,6 +37,7 @@ ota:
 
 logger:
   level: ${logger_level}
+  tx_buffer_size: 1024
 
 improv_serial:
 


### PR DESCRIPTION
Double the logger buffer size to avoid truncating log messages
Fixes #194