### PR TITLE
Add Home Assistant services for read/write

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -332,6 +332,7 @@ void Econet::handle_response_(const std::string &datapoint_id, const uint8_t *p,
       break;
     case EconetDatapointType::UNSUPPORTED:
       ESP_LOGW(TAG, "  %s : UNSUPPORTED", datapoint_id.c_str());
+      this->send_datapoint_(datapoint_id, EconetDatapoint{.type = item_type});
       break;
   }
 }
@@ -387,8 +388,9 @@ void Econet::loop() {
     return;
   }
 
-  // Quickly send writes but delay reads.
-  if (!pending_writes_.empty() || (now - this->last_request_ > this->update_interval_millis_ / request_mods_)) {
+  // Quickly send writes or reads from the Home Assistant service but delay regular reads.
+  if (!pending_writes_.empty() || !datapoint_ids_for_read_service_.empty() ||
+      (now - this->last_request_ > this->update_interval_millis_ / request_mods_)) {
     ESP_LOGI(TAG, "request ms=%d", now);
     this->last_request_ = now;
     this->make_request_();
@@ -420,9 +422,15 @@ void Econet::write_value_(const std::string &object, EconetDatapointType type, f
 }
 
 void Econet::request_strings_() {
-  uint8_t request_mod = read_requests_++ % request_mods_;
-  std::vector<std::string> objects(request_datapoint_ids_[request_mod].begin(),
-                                   request_datapoint_ids_[request_mod].end());
+  std::vector<std::string> objects;
+  if (!datapoint_ids_for_read_service_.empty()) {
+    objects.push_back(datapoint_ids_for_read_service_.front());
+    datapoint_ids_for_read_service_.pop();
+  } else {
+    uint8_t request_mod = read_requests_++ % request_mods_;
+    std::copy(request_datapoint_ids_[request_mod].begin(), request_datapoint_ids_[request_mod].end(),
+              back_inserter(objects));
+  }
   std::vector<std::string>::iterator iter;
   for (iter = objects.begin(); iter != objects.end();) {
     if (request_once_datapoint_ids_.count(*iter) == 1 && datapoints_.count(*iter) == 1) {
@@ -549,6 +557,47 @@ void Econet::register_listener(const std::string &datapoint_id, int8_t request_m
       func(kv.second);
     }
   }
+}
+
+// Called from a Home Assistant exposed service to read a datapoint.
+// Fires a Home Assistant event: "esphome.econet_event" with the response.
+void Econet::homeassistant_read(std::string datapoint_id) {
+  register_listener(datapoint_id, -1, true, [this, datapoint_id](const EconetDatapoint &datapoint) {
+    std::map<std::string, std::string> data;
+    data["id"] = datapoint_id;
+    switch (datapoint.type) {
+      case EconetDatapointType::FLOAT:
+        data["type"] = "FLOAT";
+        data["value"] = std::to_string(datapoint.value_float);
+        break;
+      case EconetDatapointType::ENUM_TEXT:
+        data["type"] = "ENUM_TEXT";
+        data["value"] = std::to_string(datapoint.value_enum);
+        data["value_string"] = datapoint.value_string;
+        break;
+      case EconetDatapointType::TEXT:
+        data["type"] = "TEXT";
+        data["value_string"] = datapoint.value_string;
+        break;
+      case EconetDatapointType::RAW:
+        data["type"] = "RAW";
+        data["value_raw"] = format_hex_pretty(datapoint.value_raw).c_str();
+        break;
+      case EconetDatapointType::UNSUPPORTED:
+        data["type"] = "UNSUPPORTED";
+        break;
+    }
+    capi_.fire_homeassistant_event("esphome.econet_event", data);
+  });
+  datapoint_ids_for_read_service_.push(datapoint_id);
+}
+
+void Econet::homeassistant_write(std::string datapoint_id, uint8_t value) {
+  set_datapoint_(datapoint_id, EconetDatapoint{.type = EconetDatapointType::ENUM_TEXT, .value_enum = value});
+}
+
+void Econet::homeassistant_write(std::string datapoint_id, float value) {
+  set_datapoint_(datapoint_id, EconetDatapoint{.type = EconetDatapointType::FLOAT, .value_float = value});
 }
 
 }  // namespace econet

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/components/api/custom_api_device.h"
 #include "esphome/components/uart/uart.h"
 #include <map>
 #include <vector>
@@ -55,7 +56,7 @@ inline bool operator==(const EconetDatapoint &lhs, const EconetDatapoint &rhs) {
     case EconetDatapointType::RAW:
       return lhs.value_raw == rhs.value_raw;
     case EconetDatapointType::UNSUPPORTED:
-      return true;
+      return false;
   }
   return false;
 }
@@ -82,6 +83,10 @@ class Econet : public Component, public uart::UARTDevice {
   void register_listener(const std::string &datapoint_id, int8_t request_mod, bool request_once,
                          const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint = false);
 
+  void homeassistant_read(std::string datapoint_id);
+  void homeassistant_write(std::string datapoint_id, uint8_t value);
+  void homeassistant_write(std::string datapoint_id, float value);
+
  protected:
   uint32_t update_interval_millis_{30000};
   std::vector<EconetDatapointListener> listeners_;
@@ -106,6 +111,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::set<std::string> request_once_datapoint_ids_;
   std::map<std::string, EconetDatapoint> datapoints_;
   std::map<std::string, EconetDatapoint> pending_writes_;
+  std::queue<std::string> datapoint_ids_for_read_service_;
 
   uint32_t read_requests_{0};
   uint32_t last_request_{0};
@@ -116,6 +122,7 @@ class Econet : public Component, public uart::UARTDevice {
   uint32_t src_adr_{0};
   uint32_t dst_adr_{0};
   GPIOPin *flow_control_pin_{nullptr};
+  esphome::api::CustomAPIDevice capi_;
 };
 
 class EconetClient {

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -32,6 +32,24 @@ wifi:
 captive_portal:
 
 api:
+  services:
+    - service: read
+      variables:
+        id: string
+      then:
+        - lambda: id(econet_id).homeassistant_read(id);
+    - service: write_enum
+      variables:
+        id: string
+        value: int
+      then:
+        - lambda: id(econet_id).homeassistant_write(id, (uint8_t) value);
+    - service: write_float
+      variables:
+        id: string
+        value: float
+      then:
+        - lambda: id(econet_id).homeassistant_write(id, value);
 
 ota:
 
@@ -51,6 +69,7 @@ uart:
   rx_pin: ${rx_pin}
 
 econet:
+  id: econet_id
   uart_id: econet_uart
   update_interval: ${econet_update_interval}
   src_address: 0x340


### PR DESCRIPTION
From Home Assistant developer tools here is an example calling the read service:
![image](https://github.com/esphome-econet/esphome-econet/assets/9987465/9b523bed-22ae-474f-8fa8-ca4ace420134)

Received event:
![image](https://github.com/esphome-econet/esphome-econet/assets/9987465/990e8d10-6f51-49f4-81f1-c0e84be590fe)


Example calling the write service for an enum:

![image](https://github.com/esphome-econet/esphome-econet/assets/9987465/b4cbb2be-8a75-4791-b4a9-a47279ca2e5e)

Example calling the write service for a float:

![image](https://github.com/esphome-econet/esphome-econet/assets/9987465/51a43d2e-ae3d-4eed-93bb-8051570ee22c)