### PR TITLE
Adding firmware release automation

### DIFF
--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -5,10 +5,14 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        type: string
+        type: choice
         default: "patch"
         required: true
-        description: "The type of semantic version increment to make. One of major, premajor, minor, preminor, patch, prepatch, or prerelease."
+        description: "The type of semantic version increment to make."
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   update-version-strings:

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -14,6 +14,10 @@ jobs:
   update-version-strings:
     name: Update Version Strings
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
     steps:
       - name: Generate Release Version
         id: generate_release_version

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -1,0 +1,50 @@
+---
+name: Release Firmware
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        type: string
+        default: "patch"
+        required: true
+        description: "The type of semantic version increment to make. One of major, premajor, minor, preminor, patch, prepatch, or prerelease."
+
+jobs:
+  update-version-strings:
+    name: Update Version Strings
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    steps:
+      - name: Generate Release Version
+        id: generate_release_version
+        uses: zwaldowski/semver-release-action@v3
+        with:
+          bump: ${{ inputs.bump }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: "v"
+      - uses: actions/checkout@v4.1.1
+        with:
+          token: ${{ secrets.ESPHOME_ECONET_TEST_SECRET }}
+      - name: Update Project Version String
+        uses: mikefarah/yq@v4.40.3
+        with:
+          cmd: >
+            yq -i
+            '
+              .esphome.project.version = "${{ steps.generate_release_version.outputs.version_tag }}"
+            '
+            econet_base.yaml
+      - name: Commit Changes
+        uses: stefanzweifel/git-auto-commit-action@v5.0.0
+        with:
+          commit_message: "Automated project versioning update"
+          push_options: '--force'
+      - name: Create Release
+        uses: ncipollo/release-action@v1.13.0
+        with:
+          generateReleaseNotes: true
+          tag: ${{ steps.generate_release_version.outputs.version_tag }}

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -26,6 +26,7 @@ jobs:
           bump: ${{ inputs.bump }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prefix: "v"
+          dry_run: true
       - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ESPHOME_ECONET_TEST_SECRET }}

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -14,10 +14,6 @@ jobs:
   update-version-strings:
     name: Update Version Strings
     runs-on: ubuntu-latest
-    permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
-      contents: write
     steps:
       - name: Generate Release Version
         id: generate_release_version

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -13,7 +13,6 @@ substitutions:
   econet_update_interval: 30s
   econet_alarm_update_interval: 30s
   econet_alarm_history_update_interval: 60s
-
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
@@ -23,16 +22,12 @@ esphome:
   board: $board
   project:
     name: "esphome-econet.esphome-econet"
-    version: 1.7.1
-
+    version: v0.0.7
 preferences:
   flash_write_interval: "24h"
-
 wifi:
   ap:
-
 captive_portal:
-
 api:
   services:
     - service: read
@@ -58,25 +53,19 @@ api:
         value: float
       then:
         - lambda: id(econet_id).homeassistant_write(datapoint_id, value);
-
 ota:
-
 logger:
   level: ${logger_level}
   tx_buffer_size: 1024
-
 improv_serial:
-
 external_components:
   - source: ${external_components_source}
-
 uart:
   id: econet_uart
   baud_rate: 38400
   rx_buffer_size: 1500
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}
-
 econet:
   id: econet_id
   uart_id: econet_uart
@@ -86,7 +75,6 @@ econet:
     2: ${econet_alarm_history_update_interval}
     3: ${econet_alarm_history_update_interval}
   src_address: 0x340
-
 sensor:
   - platform: econet
     name: "Active Alerts"
@@ -100,7 +88,6 @@ sensor:
     name: "WiFi Signal Strength"
     id: wifi_signal_sensor
     entity_category: "diagnostic"
-
 text_sensor:
   - platform: econet
     name: "Alarm 1"
@@ -166,7 +153,6 @@ text_sensor:
     request_once: true
     icon: "mdi:information-box"
     entity_category: "diagnostic"
-
 switch:
   - platform: econet
     name: "Beep On Alarm"
@@ -204,7 +190,6 @@ switch:
     switch_datapoint: ALHISCLR
     request_mod: none
     internal: true
-
 button:
   - platform: restart
     name: "Restart ESP"


### PR DESCRIPTION
This adds a simple workflow that can be run in place of manually releasing. It will auto-generate a new semver for the release, set it to the appropriate `project:` field in econet_base.yaml, then check-in the change and create the release.