### PR TITLE
Add ability to specify src_address to filter raw datapoint reading.

### DIFF
--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -81,6 +81,7 @@ CONFIG_SCHEMA = (
                     cv.Optional(CONF_DATAPOINT_TYPE, default=DPTYPE_RAW): cv.one_of(
                         *DATAPOINT_TRIGGERS, lower=True
                     ),
+                    cv.Optional(CONF_SRC_ADDRESS, default=0): cv.uint32_t,
                 },
                 extra_validators=assign_declare_id,
             ),
@@ -127,6 +128,7 @@ async def to_code(config):
             var,
             conf[CONF_SENSOR_DATAPOINT],
             conf[CONF_REQUEST_MOD],
+            conf[CONF_SRC_ADDRESS],
         )
         await automation.build_automation(
             trigger, [(DATAPOINT_TYPES[conf[CONF_DATAPOINT_TYPE]], "x")], conf

--- a/components/econet/automation.cpp
+++ b/components/econet/automation.cpp
@@ -10,13 +10,7 @@ namespace econet {
 EconetRawDatapointUpdateTrigger::EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id,
                                                                  int8_t request_mod, uint32_t src_adr) {
   parent->register_listener(
-      sensor_id, request_mod, false,
-      [this, src_adr](const EconetDatapoint &dp) {
-        if (src_adr == 0 || dp.src_adr == src_adr) {
-          this->trigger(dp.value_raw);
-        }
-      },
-      true);
+      sensor_id, request_mod, false, [this](const EconetDatapoint &dp) { this->trigger(dp.value_raw); }, true, src_adr);
 }
 
 }  // namespace econet

--- a/components/econet/automation.cpp
+++ b/components/econet/automation.cpp
@@ -8,9 +8,15 @@ namespace esphome {
 namespace econet {
 
 EconetRawDatapointUpdateTrigger::EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id,
-                                                                 int8_t request_mod) {
+                                                                 int8_t request_mod, uint32_t src_adr) {
   parent->register_listener(
-      sensor_id, request_mod, false, [this](const EconetDatapoint &dp) { this->trigger(dp.value_raw); }, true);
+      sensor_id, request_mod, false,
+      [this, src_adr](const EconetDatapoint &dp) {
+        if (src_adr == 0 || dp.src_adr == src_adr) {
+          this->trigger(dp.value_raw);
+        }
+      },
+      true);
 }
 
 }  // namespace econet

--- a/components/econet/automation.h
+++ b/components/econet/automation.h
@@ -11,7 +11,8 @@ namespace econet {
 
 class EconetRawDatapointUpdateTrigger : public Trigger<std::vector<uint8_t>> {
  public:
-  explicit EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id, int8_t request_mod);
+  explicit EconetRawDatapointUpdateTrigger(Econet *parent, const std::string &sensor_id, int8_t request_mod,
+                                           uint32_t src_adr);
 };
 
 }  // namespace econet

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -209,7 +209,7 @@ void Econet::parse_message_(bool is_tx) {
         if (item_type == EconetDatapointType::RAW) {
           std::vector<uint8_t> raw(pdata, pdata + data_len);
           const std::string &datapoint_id = read_req_.obj_names[0];
-          this->send_datapoint_(datapoint_id, EconetDatapoint{.type = item_type, .value_raw = raw, .src_adr = src_adr});
+          this->send_datapoint_(datapoint_id, src_adr, EconetDatapoint{.type = item_type, .value_raw = raw});
         }
       } else if (read_req_.type == 2) {
         // 1st pass to validate response and avoid any buffer over-read
@@ -301,8 +301,7 @@ void Econet::handle_response_(const std::string &datapoint_id, const uint8_t *p,
       }
       float item_value = bytes_to_float(p);
       ESP_LOGI(TAG, "  %s : %f", datapoint_id.c_str(), item_value);
-      this->send_datapoint_(datapoint_id,
-                            EconetDatapoint{.type = item_type, .value_float = item_value, .src_adr = src_adr});
+      this->send_datapoint_(datapoint_id, src_adr, EconetDatapoint{.type = item_type, .value_float = item_value});
       break;
     }
     case EconetDatapointType::TEXT: {
@@ -310,7 +309,7 @@ void Econet::handle_response_(const std::string &datapoint_id, const uint8_t *p,
       len -= 3;
       std::string s = trim_trailing_whitespace((const char *) p, len);
       ESP_LOGI(TAG, "  %s : (%s)", datapoint_id.c_str(), s.c_str());
-      this->send_datapoint_(datapoint_id, EconetDatapoint{.type = item_type, .value_string = s, .src_adr = src_adr});
+      this->send_datapoint_(datapoint_id, src_adr, EconetDatapoint{.type = item_type, .value_string = s});
       break;
     }
     case EconetDatapointType::ENUM_TEXT: {
@@ -328,9 +327,8 @@ void Econet::handle_response_(const std::string &datapoint_id, const uint8_t *p,
       }
       std::string s = trim_trailing_whitespace((const char *) p + 2, item_text_len);
       ESP_LOGI(TAG, "  %s : %d (%s)", datapoint_id.c_str(), item_value, s.c_str());
-      this->send_datapoint_(
-          datapoint_id,
-          EconetDatapoint{.type = item_type, .value_enum = item_value, .value_string = s, .src_adr = src_adr});
+      this->send_datapoint_(datapoint_id, src_adr,
+                            EconetDatapoint{.type = item_type, .value_enum = item_value, .value_string = s});
       break;
     }
     case EconetDatapointType::RAW:
@@ -338,7 +336,7 @@ void Econet::handle_response_(const std::string &datapoint_id, const uint8_t *p,
       break;
     case EconetDatapointType::UNSUPPORTED:
       ESP_LOGW(TAG, "  %s : UNSUPPORTED", datapoint_id.c_str());
-      this->send_datapoint_(datapoint_id, EconetDatapoint{.type = item_type, .src_adr = src_adr});
+      this->send_datapoint_(datapoint_id, src_adr, EconetDatapoint{.type = item_type});
       break;
   }
 }
@@ -529,10 +527,10 @@ void Econet::set_datapoint_(const std::string &datapoint_id, const EconetDatapoi
     }
   }
   pending_writes_[datapoint_id] = value;
-  send_datapoint_(datapoint_id, value);
+  send_datapoint_(datapoint_id, src_adr_, value);
 }
 
-void Econet::send_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value) {
+void Econet::send_datapoint_(const std::string &datapoint_id, uint32_t src_adr, const EconetDatapoint &value) {
   if (datapoints_.count(datapoint_id) == 1) {
     EconetDatapoint old_value = datapoints_[datapoint_id];
     if (old_value == value) {
@@ -543,13 +541,16 @@ void Econet::send_datapoint_(const std::string &datapoint_id, const EconetDatapo
   datapoints_[datapoint_id] = value;
   for (auto &listener : this->listeners_) {
     if (listener.datapoint_id == datapoint_id) {
-      listener.on_datapoint(value);
+      if (listener.src_adr == 0 || listener.src_adr == src_adr) {
+        listener.on_datapoint(value);
+      }
     }
   }
 }
 
 void Econet::register_listener(const std::string &datapoint_id, int8_t request_mod, bool request_once,
-                               const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint) {
+                               const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint,
+                               uint32_t src_adr) {
   if (request_mod >= 0 && request_mod < request_datapoint_ids_.size()) {
     request_datapoint_ids_[request_mod].insert(datapoint_id);
     request_mods_ = std::max(request_mods_, (uint8_t) (request_mod + 1));
@@ -563,6 +564,7 @@ void Econet::register_listener(const std::string &datapoint_id, int8_t request_m
   }
   auto listener = EconetDatapointListener{
       .datapoint_id = datapoint_id,
+      .src_adr = src_adr,
       .on_datapoint = func,
   };
   this->listeners_.push_back(listener);

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -111,7 +111,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::vector<EconetDatapointListener> listeners_;
   ReadRequest read_req_;
   void set_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value);
-  void send_datapoint_(const std::string &datapoint_id, const EconetDatapoint &value);
+  void send_datapoint_(const std::string &datapoint_id, uint32_t src_adr, const EconetDatapoint &value);
 
   void make_request_();
   void read_buffer_(int bytes_available);

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -43,6 +43,7 @@ struct EconetDatapoint {
   };
   std::string value_string;
   std::vector<uint8_t> value_raw;
+  uint32_t src_adr;
 };
 inline bool operator==(const EconetDatapoint &lhs, const EconetDatapoint &rhs) {
   if (lhs.type != rhs.type) {
@@ -116,7 +117,7 @@ class Econet : public Component, public uart::UARTDevice {
   void parse_message_(bool is_tx);
   void parse_rx_message_();
   void parse_tx_message_();
-  void handle_response_(const std::string &datapoint_id, const uint8_t *p, uint8_t len);
+  void handle_response_(const std::string &datapoint_id, const uint8_t *p, uint8_t len, uint32_t src_adr);
 
   void transmit_message_(uint8_t command, const std::vector<uint8_t> &data);
   void request_strings_();

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -43,7 +43,6 @@ struct EconetDatapoint {
   };
   std::string value_string;
   std::vector<uint8_t> value_raw;
-  uint32_t src_adr;
 };
 inline bool operator==(const EconetDatapoint &lhs, const EconetDatapoint &rhs) {
   if (lhs.type != rhs.type) {
@@ -66,6 +65,7 @@ inline bool operator==(const EconetDatapoint &lhs, const EconetDatapoint &rhs) {
 
 struct EconetDatapointListener {
   std::string datapoint_id;
+  uint32_t src_adr;
   std::function<void(EconetDatapoint)> on_datapoint;
 };
 
@@ -93,7 +93,8 @@ class Econet : public Component, public uart::UARTDevice {
   void set_enum_datapoint_value(const std::string &datapoint_id, uint8_t value);
 
   void register_listener(const std::string &datapoint_id, int8_t request_mod, bool request_once,
-                         const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint = false);
+                         const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint = false,
+                         uint32_t src_adr = 0);
 
   void homeassistant_read(std::string datapoint_id);
   void homeassistant_write(std::string datapoint_id, uint8_t value);


### PR DESCRIPTION
With this change, you can now specify a source address to filter raw values from.

I believe this is integral to supporting https://github.com/esphome-econet/esphome-econet/issues/221

This is also intended to be a step before adding source address to all datapoints (but that is a much bigger change.

If src_address is not specified, it will default to zero which will pass through all values regardless of source address.

```
econet:
  on_datapoint_update:
    - sensor_datapoint: HWSTATUS
      src_address: 448
      datapoint_type: raw
      then:
        - lambda: |-
            static int num_executions = 0;
            num_executions += 1;
            id(temp1).publish_state(num_executions);
```