### PR TITLE
Add ability to read from specific address.

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -583,40 +583,10 @@ void Econet::register_listener(const std::string &datapoint_id, int8_t request_m
 
 // Called from a Home Assistant exposed service to read a datapoint.
 // Fires a Home Assistant event: "esphome.econet_event" with the response.
-void Econet::homeassistant_read(std::string datapoint_id) {
-  register_listener(datapoint_id, -1, true, [this, datapoint_id](const EconetDatapoint &datapoint) {
-    std::map<std::string, std::string> data;
-    data["datapoint_id"] = datapoint_id;
-    switch (datapoint.type) {
-      case EconetDatapointType::FLOAT:
-        data["type"] = "FLOAT";
-        data["value"] = std::to_string(datapoint.value_float);
-        break;
-      case EconetDatapointType::ENUM_TEXT:
-        data["type"] = "ENUM_TEXT";
-        data["value"] = std::to_string(datapoint.value_enum);
-        data["value_string"] = datapoint.value_string;
-        break;
-      case EconetDatapointType::TEXT:
-        data["type"] = "TEXT";
-        data["value_string"] = datapoint.value_string;
-        break;
-      case EconetDatapointType::RAW:
-        data["type"] = "RAW";
-        data["value_raw"] = format_hex_pretty(datapoint.value_raw).c_str();
-        break;
-      case EconetDatapointType::UNSUPPORTED:
-        data["type"] = "UNSUPPORTED";
-        break;
-    }
-    capi_.fire_homeassistant_event("esphome.econet_event", data);
-  });
-  datapoint_ids_for_read_service_.push(std::pair<std::string, uint32_t>(datapoint_id, src_adr_));
-}
-
-// Called from a Home Assistant exposed service to read a datapoint.
-// Fires a Home Assistant event: "esphome.econet_event" with the response.
-void Econet::homeassistant_read_from_address(std::string datapoint_id, uint32_t address) {
+void Econet::homeassistant_read(std::string datapoint_id, uint32_t address) {
+  if (address == 0) {
+    address = src_adr_;
+  }
   register_listener(datapoint_id, -1, true, [this, datapoint_id](const EconetDatapoint &datapoint) {
     std::map<std::string, std::string> data;
     data["datapoint_id"] = datapoint_id;

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -423,8 +423,10 @@ void Econet::write_value_(const std::string &object, EconetDatapointType type, f
 
 void Econet::request_strings_() {
   std::vector<std::string> objects;
+  uint32_t dst_adr = dst_adr_;
   if (!datapoint_ids_for_read_service_.empty()) {
-    objects.push_back(datapoint_ids_for_read_service_.front());
+    objects.push_back(datapoint_ids_for_read_service_.front().first);
+    dst_adr = datapoint_ids_for_read_service_.front().second;
     datapoint_ids_for_read_service_.pop();
   } else {
     // Impose a longer delay restriction for general periodically requested messages
@@ -468,16 +470,22 @@ void Econet::request_strings_() {
 
   join_obj_names(objects, &data);
 
-  transmit_message_(READ_COMMAND, data);
+  transmit_message_(READ_COMMAND, data, dst_adr);
 }
 
-void Econet::transmit_message_(uint8_t command, const std::vector<uint8_t> &data) {
+void Econet::transmit_message_(uint8_t command, const std::vector<uint8_t> &data, uint32_t dst_adr, uint32_t src_adr) {
+  if (dst_adr == 0) {
+    dst_adr = dst_adr_;
+  }
+  if (src_adr == 0) {
+    src_adr = src_adr_;
+  }
   last_request_ = loop_now_;
 
   tx_message_.clear();
 
-  address_to_bytes(dst_adr_, &tx_message_);
-  address_to_bytes(src_adr_, &tx_message_);
+  address_to_bytes(dst_adr, &tx_message_);
+  address_to_bytes(src_adr, &tx_message_);
 
   tx_message_.push_back(data.size());
   tx_message_.push_back(0);
@@ -603,9 +611,41 @@ void Econet::homeassistant_read(std::string datapoint_id) {
     }
     capi_.fire_homeassistant_event("esphome.econet_event", data);
   });
-  datapoint_ids_for_read_service_.push(datapoint_id);
+  datapoint_ids_for_read_service_.push(std::pair<std::string, uint32_t>(datapoint_id, src_adr_));
 }
 
+// Called from a Home Assistant exposed service to read a datapoint.
+// Fires a Home Assistant event: "esphome.econet_event" with the response.
+void Econet::homeassistant_read_from_address(std::string datapoint_id, uint32_t address) {
+  register_listener(datapoint_id, -1, true, [this, datapoint_id](const EconetDatapoint &datapoint) {
+    std::map<std::string, std::string> data;
+    data["datapoint_id"] = datapoint_id;
+    switch (datapoint.type) {
+      case EconetDatapointType::FLOAT:
+        data["type"] = "FLOAT";
+        data["value"] = std::to_string(datapoint.value_float);
+        break;
+      case EconetDatapointType::ENUM_TEXT:
+        data["type"] = "ENUM_TEXT";
+        data["value"] = std::to_string(datapoint.value_enum);
+        data["value_string"] = datapoint.value_string;
+        break;
+      case EconetDatapointType::TEXT:
+        data["type"] = "TEXT";
+        data["value_string"] = datapoint.value_string;
+        break;
+      case EconetDatapointType::RAW:
+        data["type"] = "RAW";
+        data["value_raw"] = format_hex_pretty(datapoint.value_raw).c_str();
+        break;
+      case EconetDatapointType::UNSUPPORTED:
+        data["type"] = "UNSUPPORTED";
+        break;
+    }
+    capi_.fire_homeassistant_event("esphome.econet_event", data);
+  });
+  datapoint_ids_for_read_service_.push(std::pair<std::string, uint32_t>(datapoint_id, address));
+}
 void Econet::homeassistant_write(std::string datapoint_id, uint8_t value) {
   set_datapoint_(datapoint_id, EconetDatapoint{.type = EconetDatapointType::ENUM_TEXT, .value_enum = value});
 }

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -95,6 +95,7 @@ class Econet : public Component, public uart::UARTDevice {
                          const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint = false);
 
   void homeassistant_read(std::string datapoint_id);
+  void homeassistant_read_from_address(std::string datapoint_id, uint32_t address);
   void homeassistant_write(std::string datapoint_id, uint8_t value);
   void homeassistant_write(std::string datapoint_id, float value);
 
@@ -118,7 +119,7 @@ class Econet : public Component, public uart::UARTDevice {
   void parse_tx_message_();
   void handle_response_(const std::string &datapoint_id, const uint8_t *p, uint8_t len);
 
-  void transmit_message_(uint8_t command, const std::vector<uint8_t> &data);
+  void transmit_message_(uint8_t command, const std::vector<uint8_t> &data, uint32_t dst_adr = 0, uint32_t src_adr = 0);
   void request_strings_();
   void write_value_(const std::string &object, EconetDatapointType type, float value);
 
@@ -140,7 +141,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::set<std::string> request_once_datapoint_ids_;
   std::map<std::string, EconetDatapoint> datapoints_;
   std::map<std::string, EconetDatapoint> pending_writes_;
-  std::queue<std::string> datapoint_ids_for_read_service_;
+  std::queue<std::pair<std::string, uint32_t>> datapoint_ids_for_read_service_;
 
   uint32_t loop_now_{0};
   uint32_t last_request_{0};

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -94,8 +94,7 @@ class Econet : public Component, public uart::UARTDevice {
   void register_listener(const std::string &datapoint_id, int8_t request_mod, bool request_once,
                          const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint = false);
 
-  void homeassistant_read(std::string datapoint_id);
-  void homeassistant_read_from_address(std::string datapoint_id, uint32_t address);
+  void homeassistant_read(std::string datapoint_id, uint32_t address = 0);
   void homeassistant_write(std::string datapoint_id, uint8_t value);
   void homeassistant_write(std::string datapoint_id, float value);
 

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -40,6 +40,12 @@ api:
         datapoint_id: string
       then:
         - lambda: id(econet_id).homeassistant_read(datapoint_id);
+    - service: read_from_address
+      variables:
+        datapoint_id: string
+        address: int
+      then:
+        - lambda: id(econet_id).homeassistant_read_from_address(datapoint_id,address);
     - service: write_enum
       variables:
         datapoint_id: string

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -45,7 +45,7 @@ api:
         datapoint_id: string
         address: int
       then:
-        - lambda: id(econet_id).homeassistant_read_from_address(datapoint_id,address);
+        - lambda: id(econet_id).homeassistant_read(datapoint_id, address);
     - service: write_enum
       variables:
         datapoint_id: string


### PR DESCRIPTION
Adds home assistant service to perform a read to a specified address.

An example of usage would be to request HRHEEMID from 0x1c0 (448).

And utilize a on_datapoint_update to read and parse the response.

Note 1: For the request to work correctly (for a raw datapoint) you must specify an on_datapoint_update so that it knows the request should have a type of 1.

```
econet:
  on_datapoint_update:
    - sensor_datapoint: HRHEEMID
      datapoint_type: raw
      then:
        - lambda: |-
            std::string str(x.begin(), x.end());
            std::string model = str.substr(4,24);
            model.erase(remove(model.begin(), model.end(), '\00'), model.end());
            id(hw_model_num).publish_state(model);
            std::string serial = str.substr(28,24);
            serial.erase(remove(serial.begin(), serial.end(), '\00'), serial.end());
            id(hw_serial_num).publish_state(serial);

text_sensor:
  - platform: template
    name: "HW Model Num"
    id: hw_model_num
    entity_category: "diagnostic"
  - platform: template
    name: "HW Serial Num"
    id: hw_serial_num
    entity_category: "diagnostic"
```

