### PR TITLE
Add ability to specify an address for a request_mod.

### DIFF
--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -19,6 +19,7 @@ CONF_DATAPOINT_TYPE = "datapoint_type"
 CONF_REQUEST_MOD = "request_mod"
 CONF_REQUEST_ONCE = "request_once"
 CONF_REQUEST_MOD_UPDATE_INTERVALS = "request_mod_update_intervals"
+CONF_REQUEST_MOD_ADDRESSES = "request_mod_addresses"
 
 econet_ns = cg.esphome_ns.namespace("econet")
 Econet = econet_ns.class_("Econet", cg.Component, uart.UARTDevice)
@@ -65,6 +66,13 @@ def validate_request_mod_update_intervals(value):
     return value
 
 
+def validate_request_mod_addresses(value):
+    cv.check_not_templatable(value)
+    options_map_schema = cv.Schema({validate_request_mod_range: cv.uint32_t})
+    value = options_map_schema(value)
+    return value
+
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
@@ -89,6 +97,7 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_REQUEST_MOD_UPDATE_INTERVALS
             ): validate_request_mod_update_intervals,
+            cv.Optional(CONF_REQUEST_MOD_ADDRESSES): validate_request_mod_addresses,
         }
     )
     .extend(cv.polling_component_schema("30s"))
@@ -118,6 +127,14 @@ async def to_code(config):
             var.set_request_mod_update_intervals(
                 list(request_mod_update_intervals.keys()),
                 list(request_mod_update_intervals.values()),
+            )
+        )
+    if CONF_REQUEST_MOD_ADDRESSES in config:
+        request_mod_addresses = config[CONF_REQUEST_MOD_ADDRESSES]
+        cg.add(
+            var.set_request_mod_addresses(
+                list(request_mod_addresses.keys()),
+                list(request_mod_addresses.values()),
             )
         )
     if CONF_FLOW_CONTROL_PIN in config:

--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -68,8 +68,8 @@ def validate_request_mod_update_intervals(value):
 
 def validate_request_mod_addresses(value):
     cv.check_not_templatable(value)
-    options_map_schema2 = cv.Schema({validate_request_mod_range: cv.uint32_t})
-    value = options_map_schema2(value)
+    options_map_schema = cv.Schema({validate_request_mod_range: cv.uint32_t})
+    value = options_map_schema(value)
     return value
 
 

--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -68,8 +68,8 @@ def validate_request_mod_update_intervals(value):
 
 def validate_request_mod_addresses(value):
     cv.check_not_templatable(value)
-    options_map_schema = cv.Schema({validate_request_mod_range: cv.uint32_t})
-    value = options_map_schema(value)
+    options_map_schema2 = cv.Schema({validate_request_mod_range: cv.uint32_t})
+    value = options_map_schema2(value)
     return value
 
 

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -437,6 +437,7 @@ void Econet::request_strings_() {
       if ((loop_now_ - request_mod_last_requested_[request_mod]) >= request_mod_update_interval_millis_[request_mod]) {
         std::copy(request_datapoint_ids_[request_mod].begin(), request_datapoint_ids_[request_mod].end(),
                   back_inserter(objects));
+        dst_adr = request_mod_addresses_[request_mod];
         request_mod_last_requested_[request_mod] = loop_now_;
         break;
       }

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -6,7 +6,7 @@ namespace econet {
 static const char *const TAG = "econet";
 
 static const uint32_t RECEIVE_TIMEOUT = 100;
-static const uint32_t REQUEST_DELAY = 200;
+static const uint32_t REQUEST_DELAY = 100;
 
 static const uint8_t DST_ADR_POS = 0;
 static const uint8_t SRC_ADR_POS = 5;
@@ -435,8 +435,6 @@ void Econet::request_strings_() {
     }
     for (int request_mod = 0; request_mod < request_mods_; request_mod++) {
       if ((loop_now_ - request_mod_last_requested_[request_mod]) >= request_mod_update_interval_millis_[request_mod]) {
-        ESP_LOGI(TAG, "[%d] request_mod = %d of %d to %d at rate of %d", loop_now_, request_mod, request_mods_,
-                 request_mod_addresses_[request_mod], request_mod_update_interval_millis_[request_mod]);
         std::copy(request_datapoint_ids_[request_mod].begin(), request_datapoint_ids_[request_mod].end(),
                   back_inserter(objects));
         request_mod_last_requested_[request_mod] = loop_now_;
@@ -564,8 +562,7 @@ void Econet::register_listener(const std::string &datapoint_id, int8_t request_m
                                uint32_t src_adr) {
   if (request_mod >= 0 && request_mod < request_datapoint_ids_.size()) {
     request_datapoint_ids_[request_mod].insert(datapoint_id);
-    // request_mods_ = std::max(request_mods_, (uint8_t) (request_mod + 1));
-    request_mods_ = 6;
+    request_mods_ = std::max(request_mods_, (uint8_t) (request_mod + 1));
     min_delay_between_read_requests_ = std::max(min_update_interval_millis_ / request_mods_, REQUEST_DELAY);
     if (request_once) {
       request_once_datapoint_ids_.insert(datapoint_id);

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -6,7 +6,7 @@ namespace econet {
 static const char *const TAG = "econet";
 
 static const uint32_t RECEIVE_TIMEOUT = 100;
-static const uint32_t REQUEST_DELAY = 100;
+static const uint32_t REQUEST_DELAY = 200;
 
 static const uint8_t DST_ADR_POS = 0;
 static const uint8_t SRC_ADR_POS = 5;
@@ -435,10 +435,12 @@ void Econet::request_strings_() {
     }
     for (int request_mod = 0; request_mod < request_mods_; request_mod++) {
       if ((loop_now_ - request_mod_last_requested_[request_mod]) >= request_mod_update_interval_millis_[request_mod]) {
+        ESP_LOGI(TAG, "[%d] request_mod = %d of %d to %d at rate of %d", loop_now_, request_mod, request_mods_,
+                 request_mod_addresses_[request_mod], request_mod_update_interval_millis_[request_mod]);
         std::copy(request_datapoint_ids_[request_mod].begin(), request_datapoint_ids_[request_mod].end(),
                   back_inserter(objects));
-        dst_adr = request_mod_addresses_[request_mod];
         request_mod_last_requested_[request_mod] = loop_now_;
+        dst_adr = request_mod_addresses_[request_mod];
         break;
       }
     }
@@ -562,7 +564,8 @@ void Econet::register_listener(const std::string &datapoint_id, int8_t request_m
                                uint32_t src_adr) {
   if (request_mod >= 0 && request_mod < request_datapoint_ids_.size()) {
     request_datapoint_ids_[request_mod].insert(datapoint_id);
-    request_mods_ = std::max(request_mods_, (uint8_t) (request_mod + 1));
+    // request_mods_ = std::max(request_mods_, (uint8_t) (request_mod + 1));
+    request_mods_ = 6;
     min_delay_between_read_requests_ = std::max(min_update_interval_millis_ / request_mods_, REQUEST_DELAY);
     if (request_once) {
       request_once_datapoint_ids_.insert(datapoint_id);

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -109,10 +109,10 @@ class Econet : public Component, public uart::UARTDevice {
  protected:
   uint32_t update_interval_millis_{30000};
   std::map<uint8_t, uint32_t> request_mod_addresses_map_;
-  std::vector<uint32_t> request_mod_addresses_ = std::vector<uint32_t>{MAX_REQUEST_MODS, 0};
+  std::vector<uint32_t> request_mod_addresses_ = std::vector<uint32_t>(MAX_REQUEST_MODS, 0);
   std::map<uint8_t, uint32_t> request_mod_update_interval_millis_map_;
   std::vector<uint32_t> request_mod_update_interval_millis_ =
-      std::vector<uint32_t>{MAX_REQUEST_MODS, update_interval_millis_};
+      std::vector<uint32_t>(MAX_REQUEST_MODS, update_interval_millis_);
   uint32_t min_update_interval_millis_{update_interval_millis_};
   uint32_t min_delay_between_read_requests_{update_interval_millis_};
 

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -78,10 +78,12 @@ class Econet : public Component, public uart::UARTDevice {
   void set_src_address(uint32_t address) { src_adr_ = address; }
   void set_dst_address(uint32_t address) { dst_adr_ = address; }
   void set_request_mod_addresses(std::vector<uint8_t> request_mods, std::vector<uint32_t> addresses) {
-    for (auto i = 0; i < request_mods.size(); i++) {
-      request_mod_addresses_map_[request_mods[i]] = addresses[i];
+    for (auto i = 0; i < MAX_REQUEST_MODS; i++) {
+      request_mod_addresses_[i] = 0;
     }
-    update_addresses_();
+    for (auto i = 0; i < request_mods.size(); i++) {
+      request_mod_addresses_[request_mods[i]] = addresses[i];
+    }
   }
   void set_request_mod_update_intervals(std::vector<uint8_t> request_mods, std::vector<uint32_t> update_intervals) {
     for (auto i = 0; i < request_mods.size(); i++) {
@@ -108,7 +110,6 @@ class Econet : public Component, public uart::UARTDevice {
 
  protected:
   uint32_t update_interval_millis_{30000};
-  std::map<uint8_t, uint32_t> request_mod_addresses_map_;
   std::vector<uint32_t> request_mod_addresses_ = std::vector<uint32_t>(MAX_REQUEST_MODS, 0);
   std::map<uint8_t, uint32_t> request_mod_update_interval_millis_map_;
   std::vector<uint32_t> request_mod_update_interval_millis_ =
@@ -131,15 +132,6 @@ class Econet : public Component, public uart::UARTDevice {
   void transmit_message_(uint8_t command, const std::vector<uint8_t> &data, uint32_t dst_adr = 0, uint32_t src_adr = 0);
   void request_strings_();
   void write_value_(const std::string &object, EconetDatapointType type, float value);
-
-  void update_addresses_() {
-    for (auto i = 0; i < MAX_REQUEST_MODS; i++) {
-      request_mod_addresses_[i] = 0;
-    }
-    for (auto &kv : this->request_mod_addresses_map_) {
-      request_mod_addresses_[kv.first] = kv.second;
-    }
-  }
 
   void update_intervals_() {
     min_update_interval_millis_ = update_interval_millis_;

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -77,6 +77,12 @@ class Econet : public Component, public uart::UARTDevice {
 
   void set_src_address(uint32_t address) { src_adr_ = address; }
   void set_dst_address(uint32_t address) { dst_adr_ = address; }
+  void set_request_mod_addresses(std::vector<uint8_t> request_mods, std::vector<uint32_t> addresses) {
+    for (auto i = 0; i < request_mods.size(); i++) {
+      request_mod_addresses_map_[request_mods[i]] = addresses[i];
+    }
+    update_addresses_();
+  }
   void set_request_mod_update_intervals(std::vector<uint8_t> request_mods, std::vector<uint32_t> update_intervals) {
     for (auto i = 0; i < request_mods.size(); i++) {
       request_mod_update_interval_millis_map_[request_mods[i]] = update_intervals[i];
@@ -102,6 +108,8 @@ class Econet : public Component, public uart::UARTDevice {
 
  protected:
   uint32_t update_interval_millis_{30000};
+  std::map<uint8_t, uint32_t> request_mod_addresses_map_;
+  std::vector<uint32_t> request_mod_addresses_ = std::vector<uint32_t>{MAX_REQUEST_MODS, 0};
   std::map<uint8_t, uint32_t> request_mod_update_interval_millis_map_;
   std::vector<uint32_t> request_mod_update_interval_millis_ =
       std::vector<uint32_t>{MAX_REQUEST_MODS, update_interval_millis_};
@@ -123,6 +131,15 @@ class Econet : public Component, public uart::UARTDevice {
   void transmit_message_(uint8_t command, const std::vector<uint8_t> &data, uint32_t dst_adr = 0, uint32_t src_adr = 0);
   void request_strings_();
   void write_value_(const std::string &object, EconetDatapointType type, float value);
+
+  void update_addresses_() {
+    for (auto i = 0; i < MAX_REQUEST_MODS; i++) {
+      request_mod_addresses_[i] = 0;
+    }
+    for (auto &kv : this->request_mod_update_interval_millis_map_) {
+      request_mod_addresses_[kv.first] = kv.second;
+    }
+  }
 
   void update_intervals_() {
     min_update_interval_millis_ = update_interval_millis_;

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -136,7 +136,7 @@ class Econet : public Component, public uart::UARTDevice {
     for (auto i = 0; i < MAX_REQUEST_MODS; i++) {
       request_mod_addresses_[i] = 0;
     }
-    for (auto &kv : this->request_mod_update_interval_millis_map_) {
+    for (auto &kv : this->request_mod_addresses_map_) {
       request_mod_addresses_[kv.first] = kv.second;
     }
   }

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -85,9 +85,6 @@ econet:
     1: ${econet_alarm_update_interval}
     2: ${econet_alarm_history_update_interval}
     3: ${econet_alarm_history_update_interval}
-#    5: 30s
-  request_mod_addresses:
-    5: 448
   src_address: 0x340
 
 sensor:

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -85,6 +85,9 @@ econet:
     1: ${econet_alarm_update_interval}
     2: ${econet_alarm_history_update_interval}
     3: ${econet_alarm_history_update_interval}
+#    5: 30s
+  request_mod_addresses:
+    5: 448
   src_address: 0x340
 
 sensor:


### PR DESCRIPTION
The following is an example of how this functionality can be used to specify that request_mod 5 should be directed towards address 448 instead of the auto-detected value of dst_adr_. If not specified, the default value will be 0, which will cause the request to go to dst_adr_.

```
econet:
  request_mod_addresses:
    5: 448
  on_datapoint_update:
    - sensor_datapoint: HRHEEMID
      request_mod: 5
      datapoint_type: raw
      then:
        - lambda: |-
            std::string str(x.begin(), x.end());
            std::string model = str.substr(4,24);
            model.erase(remove(model.begin(), model.end(), '\00'), model.end());
            id(hw_model_num).publish_state(model);
            std::string serial = str.substr(28,24);
            serial.erase(remove(serial.begin(), serial.end(), '\00'), serial.end());
            id(hw_serial_num).publish_state(serial);


text_sensor:
  - platform: template
    name: "HW Model Num"
    id: hw_model_num
    entity_category: "diagnostic"
  - platform: template
    name: "HW Serial Num"
    id: hw_serial_num
    entity_category: "diagnostic"

```