### PR TITLE
fix(#258): Use PAT for release generation.

### DIFF
--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -18,8 +18,6 @@ jobs:
   update-version-strings:
     name: Update Version Strings
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Generate Release Version
         id: generate_release_version

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -51,3 +51,4 @@ jobs:
         with:
           generateReleaseNotes: true
           tag: ${{ steps.generate_release_version.outputs.version_tag }}
+          token: ${{ secrets.RELEASE_AUTOMATION_ACTION }}


### PR DESCRIPTION
Fix #258

Tested this on the source branch :
https://github.com/barndawgie/esphome-econet/actions/runs/7216698219
ran and kicked off
https://github.com/barndawgie/esphome-econet/actions/runs/7216700018