### PR TITLE
chore: Update dependabot config to reduce frequency and number of updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,11 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+    rebase-strategy: auto
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
The `groups` directive should cause all github-actions updates to be sent in a single PR rather than a separate PR for each updated dependency.