### PR TITLE
fix: Dependabot config file failing to parse.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     open-pull-requests-limit: 10
     groups:
       github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"


### PR DESCRIPTION
Dependabot documentation was vague on this but validation appears to be failing: https://github.com/esphome-econet/esphome-econet/runs/19689463154

I'm not sure why that status check didn't run on the PR but only after the push...