### PR TITLE
chore: Remove minor versions from github-actions dependencies

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Download built firmwares
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v4
         with:
           path: firmwares
       - name: Dump Files
@@ -49,7 +49,7 @@ jobs:
         run: |-
           jq -s '{"name": "esphome-econet", "new_install_improv_wait_time": 15, "new_install_prompt_erase": false, "version": "${{ github.ref_name }}", "home_assistant_domain": "esphome", "builds":.}' firmwares/*/econet-${{ matrix.appliance.shorthand }}-*/manifest.json > output/econet-${{ matrix.appliance.shorthand }}.json
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: econet-${{ matrix.appliance.shorthand }}
           path: output
@@ -61,9 +61,9 @@ jobs:
     needs: consolidate-manifests
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Download built firmwares
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v4
         with:
           path: firmwares
       - name: Dump Files
@@ -75,7 +75,7 @@ jobs:
           cp -R firmwares/*/* output/
           ls -R output/
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v2.0.0
+        uses: actions/upload-pages-artifact@v2
         with:
           path: output
 
@@ -91,7 +91,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v4.0.0
+        uses: actions/configure-pages@v4
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3.0.1
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -21,7 +21,7 @@ jobs:
     needs: build
     if: failure()
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4
       - name: Create Issue on Failure
         uses: JasonEtco/create-an-issue@v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
             shorthand: tlwh
       fail-fast: true
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4
       - name: Force Manifest to Build Local Code
-        uses: mikefarah/yq@v4.40.5
+        uses: mikefarah/yq@v4
         with:
           cmd: >
             yq -P -i
@@ -50,7 +50,7 @@ jobs:
             build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Build Firmware
         id: esphome-build
-        uses: esphome/build-action@v1.8.0
+        uses: esphome/build-action@v1
         with:
           yaml_file: build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Copy firmware and manifest
@@ -60,7 +60,7 @@ jobs:
           mv ${{ steps.esphome-build.outputs.name }} output/
       - name: Upload artifact
         if: ${{ inputs.upload-artifacts }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}
           path: output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Force Manifest to Build Local Code
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: >
             yq -P -i

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_AUTOMATION_ACTION }}
       - name: Update Project Version String
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: >
             yq -i

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -27,11 +27,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prefix: "v"
           dry_run: true
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.RELEASE_AUTOMATION_ACTION }}
       - name: Update Project Version String
-        uses: mikefarah/yq@v4.40.5
+        uses: mikefarah/yq@v4
         with:
           cmd: >
             yq -i
@@ -40,12 +40,12 @@ jobs:
             '
             econet_base.yaml
       - name: Commit Changes
-        uses: stefanzweifel/git-auto-commit-action@v5.0.0
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Automated project versioning update"
           push_options: '--force'
       - name: Create Release
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true
           tag: ${{ steps.generate_release_version.outputs.version_tag }}


### PR DESCRIPTION
This will remove the need for github-actions dependencies to go through PR unless there are breaking/major version updates.