### PR TITLE
chore: Specifying precise esphome/build-action workflow version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
             build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Build Firmware
         id: esphome-build
-        uses: esphome/build-action@v1
+        uses: esphome/build-action@v1.8.0
         with:
           yaml_file: build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Copy firmware and manifest


### PR DESCRIPTION
We're currently pulling an old version of the workflow due to: https://github.com/esphome/build-action/issues/18