### PR TITLE
chore: Cleaning up duplicative strings in dependabot PR messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
This should fix dependabot PR messages from:
`chore(deps)(deps): bump the github-actions group with 2 updates`
to
`chore(deps): bump the github-actions group with 2 updates`