### PR TITLE
ci: Removing specifiction of yq action release tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Force Manifest to Build Local Code
-        uses: mikefarah/yq@v4.40.5
+        uses: mikefarah/yq@v4
         with:
           cmd: >
             yq -P -i
@@ -53,7 +53,7 @@ jobs:
             build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Force Verbose Logging
         if: ${{ inputs.force-verbose-logging }}
-        uses: mikefarah/yq@v4.40.5
+        uses: mikefarah/yq@v4
         with:
           cmd: >
             yq -P -i

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
         required: false
         default: false
-        description: "Set to true to have this workflow for verbose logging, useful for catching build failures in logging code."
+        description: "Set to true to have this workflow force verbose logging, useful for catching build failures in logging code."
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_AUTOMATION_ACTION }}
       - name: Update Project Version String
-        uses: mikefarah/yq@v4.40.5
+        uses: mikefarah/yq@v4
         with:
           cmd: >
             yq -i


### PR DESCRIPTION
Now that [yq action's versioning if fixed](https://github.com/mikefarah/yq/issues/1908#event-11384744338), we can remove the specific of a specific release tag.