### PR TITLE
adding outdoor and supply air temperature to furnace hwstatus parsing

### DIFF
--- a/econet_hvac_furnace.yaml
+++ b/econet_hvac_furnace.yaml
@@ -84,26 +84,28 @@ econet:
             id(furnace_sw2).publish_state(sw2);
 
 sensor:
-  - platform: template
+  - platform: econet
     name: "Supply Air Temperature"
     id: supply_air_temperature
-    #sensor_datapoint: FURNSTMP
+    sensor_datapoint: FURNSTMP
     device_class: "temperature"
     unit_of_measurement: "°F"
     state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
+    request_mod: none
     filters:
       - delta: 0.9
-  - platform: template
+  - platform: econet
     name: "Return Air Temperature"
     id: return_air_temperature
-    #sensor_datapoint: FURNRTMP
+    sensor_datapoint: FURNRTMP
     device_class: "temperature"
     unit_of_measurement: "°F"
     state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
+    request_mod: none
     filters:
       - delta: 0.9
   - platform: template

--- a/econet_hvac_furnace.yaml
+++ b/econet_hvac_furnace.yaml
@@ -84,26 +84,28 @@ econet:
             id(furnace_sw2).publish_state(sw2);
 
 sensor:
-  - platform: econet
+  - platform: template
     name: "Supply Air Temperature"
     id: supply_air_temperature
-    sensor_datapoint: FURNSTMP
+    #sensor_datapoint: FURNSTMP
     device_class: "temperature"
     unit_of_measurement: "°F"
     state_class: "measurement"
     entity_category: "diagnostic"
+    accuracy_decimals: 0
     filters:
-      - delta: 0.91
-  - platform: econet
+      - delta: 0.9
+  - platform: template
     name: "Return Air Temperature"
     id: return_air_temperature
-    sensor_datapoint: FURNRTMP
+    #sensor_datapoint: FURNRTMP
     device_class: "temperature"
     unit_of_measurement: "°F"
     state_class: "measurement"
     entity_category: "diagnostic"
+    accuracy_decimals: 0
     filters:
-      - delta: 0.91
+      - delta: 0.9
   - platform: template
     name: "Outdoor Air Temperature"
     id: outdoor_air_temperature
@@ -111,8 +113,9 @@ sensor:
     unit_of_measurement: "°F"
     state_class: "measurement"
     entity_category: "diagnostic"
+    accuracy_decimals: 0
     filters:
-      - delta: 0.91
+      - delta: 0.9
   - platform: template
     name: "Flame Sensor"
     id: flame_sensor

--- a/econet_hvac_furnace.yaml
+++ b/econet_hvac_furnace.yaml
@@ -29,6 +29,7 @@ econet:
             id(heat_stage).publish_state(x[26]);
             id(static_pressure).publish_state(((x[15] << 8) + x[16]) / 5280.0);
             id(return_air_temperature).publish_state(((x[50] << 8) + x[51]) / 10.0);
+            id(outdoor_air_temperature).publish_state(((x[52] << 8) + x[53])/10.0);
             id(flame_sensor).publish_state(x[33] / 10.0);
             // Accumulators
             id(low_heat_2week_cycles).publish_state((x[102] << 8) + x[103]);
@@ -46,6 +47,7 @@ econet:
             id(high_heat_lifetime_hrs).publish_state((x[132] << 8) + x[133]);
             id(blower_lifetime_hrs).publish_state((x[135] << 8) + x[136]);
             id(powered_lifetime_days).publish_state((x[137] << 8) + x[138]);
+            id(supply_air_temperature).publish_state(((x[145] << 8) + x[146])/10.0);
     - sensor_datapoint: HRHEEMID
       request_mod: 5
       request_once: true
@@ -91,7 +93,7 @@ sensor:
     state_class: "measurement"
     entity_category: "diagnostic"
     filters:
-      - delta: 0.9
+      - delta: 0.91
   - platform: econet
     name: "Return Air Temperature"
     id: return_air_temperature
@@ -101,7 +103,16 @@ sensor:
     state_class: "measurement"
     entity_category: "diagnostic"
     filters:
-      - delta: 0.9
+      - delta: 0.91
+  - platform: template
+    name: "Outdoor Air Temperature"
+    id: outdoor_air_temperature
+    device_class: "temperature"
+    unit_of_measurement: "°F"
+    state_class: "measurement"
+    entity_category: "diagnostic"
+    filters:
+      - delta: 0.91
   - platform: template
     name: "Flame Sensor"
     id: flame_sensor


### PR DESCRIPTION
closes #327 

Explicitly setting decimal precision of template sensor values to zero to match EspHome-econet sensor convention. 