### PR TITLE
feat: Adding esp32s3 configurations

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,6 +5,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+        required: false
+        description: "Dry Run: Don't actually deploy to github-pages"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -80,6 +86,7 @@ jobs:
           path: output
 
   deploy:
+    if: ${{ ! inputs.dry_run }}
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: consolidate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [esp32, esp8266]
+        platform: [esp32, esp32s3, esp8266]
         appliance:
           - name: electric_tank_water_heater
             shorthand: etwh

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ sdkconfig.*
 !sdkconfig.defaults
 
 .tests/
+
+# ESPHome-Econet Ignores
+build-yaml/.gitignore

--- a/build-yaml/econet-etwh-esp32s3.yaml
+++ b/build-yaml/econet-etwh-esp32s3.yaml
@@ -1,0 +1,29 @@
+---
+substitutions:
+  tx_pin: GPIO6
+  rx_pin: GPIO5
+  board: esp32-s3-devkitc-1
+  platform: esp32s3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_electric_tank_water_heater.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: esp32s3
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-etwh-esp32s3.yaml
+++ b/build-yaml/econet-etwh-esp32s3.yaml
@@ -3,7 +3,8 @@ substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
   board: esp32-s3-devkitc-1
-  platform: esp32s3
+  platform: esp32
+  variant: esp32s3
 
 packages:
   econet:
@@ -12,7 +13,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
 esphome:
@@ -21,7 +22,7 @@ esphome:
 
 esp32:
   board: ${board}
-  variant: esp32s3
+  variant: ${variant}
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hpwh-esp32s3.yaml
+++ b/build-yaml/econet-hpwh-esp32s3.yaml
@@ -3,7 +3,8 @@ substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
   board: esp32-s3-devkitc-1
-  platform: esp32s3
+  platform: esp32
+  variant: esp32s3
 
 packages:
   econet:
@@ -12,7 +13,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
 esphome:
@@ -21,7 +22,7 @@ esphome:
 
 esp32:
   board: ${board}
-  variant: esp32s3
+  variant: ${variant}
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hpwh-esp32s3.yaml
+++ b/build-yaml/econet-hpwh-esp32s3.yaml
@@ -1,0 +1,29 @@
+---
+substitutions:
+  tx_pin: GPIO6
+  rx_pin: GPIO5
+  board: esp32-s3-devkitc-1
+  platform: esp32s3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_heatpump_water_heater.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: esp32s3
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-hvac_air_handler-esp32s3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32s3.yaml
@@ -1,0 +1,34 @@
+---
+substitutions:
+  tx_pin: GPIO6
+  rx_pin: GPIO5
+  board: esp32-s3-devkitc-1
+  platform: esp32s3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_hvac_air_handler.yaml
+  # Uncomment if you have an communicationg Outdoor Unit
+  # econet-hvac-odu:
+  #   url: https://github.com/esphome-econet/esphome-econet
+  #   ref: main
+  #   file: econet_hvac_odu.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: esp32s3
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-hvac_air_handler-esp32s3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32s3.yaml
@@ -3,7 +3,8 @@ substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
   board: esp32-s3-devkitc-1
-  platform: esp32s3
+  platform: esp32
+  variant: esp32s3
 
 packages:
   econet:
@@ -17,7 +18,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
 esphome:
@@ -26,7 +27,7 @@ esphome:
 
 esp32:
   board: ${board}
-  variant: esp32s3
+  variant: ${variant}
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hvac_furnace-esp32s3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32s3.yaml
@@ -3,7 +3,8 @@ substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
   board: esp32-s3-devkitc-1
-  platform: esp32s3
+  platform: esp32
+  variant: esp32s3
 
 packages:
   econet:
@@ -17,7 +18,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
 esphome:
@@ -26,7 +27,7 @@ esphome:
 
 esp32:
   board: ${board}
-  variant: esp32s3
+  variant: ${variant}
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hvac_furnace-esp32s3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32s3.yaml
@@ -1,0 +1,34 @@
+---
+substitutions:
+  tx_pin: GPIO6
+  rx_pin: GPIO5
+  board: esp32-s3-devkitc-1
+  platform: esp32s3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_hvac_furnace.yaml
+  # Uncomment if you have an communicationg Outdoor Unit
+  # econet-hvac-odu:
+  #   url: https://github.com/esphome-econet/esphome-econet
+  #   ref: main
+  #   file: econet_hvac_odu.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: esp32s3
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-tlwh-esp32s3.yaml
+++ b/build-yaml/econet-tlwh-esp32s3.yaml
@@ -3,7 +3,8 @@ substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
   board: esp32-s3-devkitc-1
-  platform: esp32s3
+  platform: esp32
+  variant: esp32s3
 
 packages:
   econet:
@@ -12,7 +13,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
 esphome:
@@ -21,7 +22,7 @@ esphome:
 
 esp32:
   board: ${board}
-  variant: esp32s3
+  variant: ${variant}
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-tlwh-esp32s3.yaml
+++ b/build-yaml/econet-tlwh-esp32s3.yaml
@@ -1,0 +1,29 @@
+---
+substitutions:
+  tx_pin: GPIO6
+  rx_pin: GPIO5
+  board: esp32-s3-devkitc-1
+  platform: esp32s3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_tankless_water_heater.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: esp32s3
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password


### PR DESCRIPTION
This adds esp32s3 configurations to `./build-yaml/` and builds them as part of our existing build process, including publishing to Web Tools. I verified via installation onto an m5stack atoms3 lite via Web Tools from https://barndawgie.github.io/install