### PR TITLE
fix: Adding lambda to solve AFUE reporting of waste

### DIFF
--- a/econet_hvac_furnace.yaml
+++ b/econet_hvac_furnace.yaml
@@ -137,6 +137,10 @@ sensor:
     unit_of_measurement: "%"
     icon: "mdi:fire-circle"
     request_once: true
+    filters:
+      - lambda: |-  # Some furnaces seem to report waste rather than efficiency; this normalizes things to traditional AFUE
+          if (x < 50) return 100-x;
+          return x;
   - platform: econet
     name: "Furnace High Heat BTU Output"
     id: furnace_hh_btus


### PR DESCRIPTION
AFUE sometimes seem to report waste rather than efficiency. This lambda fixes this (assuming that no actual furnace will have efficiency below 50%).