### PR TITLE
fix: Set Expansion Valve Current position unit to "%"

### DIFF
--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -43,6 +43,7 @@ sensor:
     sensor_datapoint: EXACTUAL
     request_mod: none
     accuracy_decimals: 1
+    unit_of_measurement: "%"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Expansion Valve Super Heat"


### PR DESCRIPTION
Thermostat displays this as a percentage, and we should match that