### PR TITLE
Change ODU Defrost to a binary_sensor

### DIFF
--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -254,7 +254,7 @@ binary_sensor:
     request_mod: none
     device_class: running
     entity_category: "diagnostic"
-    
+
 text_sensor:
   - platform: econet
     name: "ODU Model Number"

--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -247,7 +247,7 @@ sensor:
     accuracy_decimals: 1
 
 binary_sensor:
- - platform: econet
+  - platform: econet
     name: "ODU Defrost"
     id: odu_defrost
     sensor_datapoint: ODU_DEFR

--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -93,13 +93,6 @@ sensor:
     state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
-    name: "ODU Defrost"
-    id: odu_defrost
-    sensor_datapoint: ODU_DEFR
-    request_mod: none
-    accuracy_decimals: 1
-    entity_category: "diagnostic"
-  - platform: econet
     name: "ODU Low Cool Two Week Hours"
     id: odu_low_cool_two_week_hours
     sensor_datapoint: ODURCS1H
@@ -253,6 +246,15 @@ sensor:
     unit_of_measurement: "kWh"
     accuracy_decimals: 1
 
+binary_sensor:
+ - platform: econet
+    name: "ODU Defrost"
+    id: odu_defrost
+    sensor_datapoint: ODU_DEFR
+    request_mod: none
+    device_class: running
+    entity_category: "diagnostic"
+    
 text_sensor:
   - platform: econet
     name: "ODU Model Number"


### PR DESCRIPTION
This allows the data point to be displayed as "running" or "not running" which is less confusing than '1' or '0'