### PR TITLE
Add Support for ODU SIze (in Tons) and Type

### DIFF
--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -258,6 +258,7 @@ sensor:
     sensor_datapoint: ODU_SIZE
     request_once: true
     request_mod: 7
+    accuracy_decimals: 1
     icon: "mdi:information-box"
     entity_category: "diagnostic"
   - platform: econet

--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -268,7 +268,7 @@ sensor:
     request_mod: 7
     icon: "mdi:information-box"
     entity_category: "diagnostic"
-    
+
 binary_sensor:
   - platform: template
     name: "ODU Defrost"

--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -252,7 +252,23 @@ sensor:
     request_mod: none
     accuracy_decimals: 0
     internal: true
-
+  - platform: econet
+    name: "ODU Size (Tons)"
+    id: odu_size
+    sensor_datapoint: ODU_SIZE
+    request_once: true
+    request_mod: 7
+    icon: "mdi:information-box"
+    entity_category: "diagnostic"
+  - platform: econet
+    name: "ODU Type"
+    id: odu_type
+    sensor_datapoint: ODU_TYPE
+    request_once: true
+    request_mod: 7
+    icon: "mdi:information-box"
+    entity_category: "diagnostic"
+    
 binary_sensor:
   - platform: template
     name: "ODU Defrost"


### PR DESCRIPTION
ODU_SIZE
ODU_TYPE (Believe 1 means communicating, 0 means non-communicating)

Need someone with a non-communicating model to confirm.  Someone with an RP20 series, too, would be helpful 