### PR TITLE
chore(deps): Remove specific build-action version now that v1 tag is fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
             build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Build Firmware
         id: esphome-build
-        uses: esphome/build-action@v1.9.0
+        uses: esphome/build-action@v1
         with:
           yaml_file: build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Copy firmware and manifest


### PR DESCRIPTION
Now that https://github.com/esphome/build-action/issues/18 is fixed, we no longer need to depend on a specific v1.* tag.