### PR TITLE
ci: Adding esphome build caching for performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
         uses: esphome/build-action@v2
         with:
           yaml_file: build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
+          cache: true
       - name: Copy firmware and manifest
         if: ${{ inputs.upload-artifacts }}
         run: |


### PR DESCRIPTION
Caching has been added to the official ESPHome build-action - enabling it to (hopefully) improve build performance.