### PR TITLE
Remove captive_portal

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -27,8 +27,6 @@ esphome:
 preferences:
   flash_write_interval: "24h"
 wifi:
-  ap:
-captive_portal:
 api:
   services:
     - service: read


### PR DESCRIPTION
Mostly need to remove it to reduce resources for ESP8266 see #365. But I thought it would be good to remove it for all. It isn't particularly useful and it's currently a security risk without a configured password. Someone nearby could use a wifi jammer to force ESPHome to enter the captive portal mode and then connect it to their own AP or even upload a new firmware.