### PR TITLE
Ignore 0 values for irtc_day

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -197,7 +197,7 @@ text_sensor:
     entity_category: "diagnostic"
     disabled_by_default: true
     lambda: |-
-      if (isnan(id(irtc_seconds).state)) {
+      if (isnan(id(irtc_day).state) || !id(irtc_day).state) {
         // Return undefined if values haven't been successfully fetched yet
         return {};
       }

--- a/econet_time.yaml
+++ b/econet_time.yaml
@@ -43,7 +43,7 @@ text_sensor:
     entity_category: "diagnostic"
     disabled_by_default: true
     lambda: |-
-      if (isnan(id(irtc_seconds).state)) {
+      if (isnan(id(irtc_day).state) || !id(irtc_day).state) {
         // Return undefined if values haven't been successfully fetched yet
         return {};
       }


### PR DESCRIPTION
This will have to be redone after #367 is merged or update #367 to include this change if this is merged first.
Note I switched to checking irtc_day instead of irtc_seconds because 0 is a valid value for seconds but not for day.