### PR TITLE
Remove alarm history 3 and 4

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -23,7 +23,7 @@ esphome:
   board: $board
   project:
     name: "esphome-econet.esphome-econet"
-    version: v1.21.0
+    version: v1.22.0
 preferences:
   flash_write_interval: "24h"
 wifi:

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -168,20 +168,6 @@ text_sensor:
     icon: "mdi:alert"
     entity_category: "diagnostic"
   - platform: econet
-    name: "Alarm History 3"
-    id: alarm_history_3
-    sensor_datapoint: ALARMH03
-    request_mod: 3
-    icon: "mdi:alert"
-    entity_category: "diagnostic"
-  - platform: econet
-    name: "Alarm History 4"
-    id: alarm_history_4
-    sensor_datapoint: ALARMH04
-    request_mod: 3
-    icon: "mdi:alert"
-    entity_category: "diagnostic"
-  - platform: econet
     name: "Software Version Number"
     id: sw_version
     sensor_datapoint: SW_VERSN


### PR DESCRIPTION
Doing this to improve #365 and avoid the request with `request_mod: 3`
No need to have that many alarm history sensors. HA keeps its own history for the 4 alarm sensors anyway. Having alarms/alerts is uncommon and 2 sensors for history should be enough.