### PR TITLE
chore(deps): Bumping build-action to generate necessary OTA files.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
             build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Build Firmware
         id: esphome-build
-        uses: esphome/build-action@v2
+        uses: esphome/build-action@v3
         with:
           yaml_file: build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
           cache: true


### PR DESCRIPTION
This is an enabler for HTTP-based OTA updates as it will update to the latest ESPHome Built-Action to create the necessary files out of our build workflow.