### PR TITLE
Switch to new esphome configuration (current one is deprecated); fix for Issue #323

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -19,11 +19,17 @@ esphome:
   friendly_name: ${friendly_name}
   comment: ${device_description}
   min_version: "2024.6.0"
-  platform: $platform
-  board: $board
+  #platform: $platform
+  #board: $board
   project:
     name: "esphome-econet.esphome-econet"
     version: v2.2.0
+
+esp32:
+  board: $board
+  framework:
+    type: esp-idf
+
 preferences:
   flash_write_interval: "24h"
 wifi:

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -7,6 +7,8 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  variant: esp32
+  framework: esp-idf
   github_ref: main
   external_components_source: github://esphome-econet/esphome-econet@${github_ref}
   logger_level: WARN
@@ -19,16 +21,15 @@ esphome:
   friendly_name: ${friendly_name}
   comment: ${device_description}
   min_version: "2024.6.0"
-  #platform: $platform
-  #board: $board
   project:
     name: "esphome-econet.esphome-econet"
     version: v2.2.0
 
-esp32:
-  board: $board
+${platform}:
+  board: ${board}
+  variant: ${variant}
   framework:
-    type: esp-idf
+    type: ${framework}
 
 preferences:
   flash_write_interval: "24h"


### PR DESCRIPTION
Current code base uses old and deprecated esphome configuration in which board parameters are configured directly in esphome section. However this is very problematic because it prevents anyone from adjusting details, such as specifying framework (arduino vs idf) or a specific variant or anything that required options under the $platform section (e.g. esp32 section).
