### PR TITLE
Reverting new min_version as it is not required.

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -18,7 +18,7 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   comment: ${device_description}
-  min_version: "2024.11.0"
+  min_version: "2024.6.0"
   platform: $platform
   board: $board
   project:


### PR DESCRIPTION
#430 updated the `min_version`, but that wasn't necessary as the bugfix is contains (fixing the unit formatting) is backwards compatible.

Tested locally with `2024.10.3`.