### PR TITLE
Update Ruff Config to Run All Default Checks and Rescan/Fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.1
+    rev: v0.8.4
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.4
+    rev: v19.1.5
     hooks:
       - id: clang-format
   - repo: https://github.com/adrienverge/yamllint.git
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/codespell-project/codespell

--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -3,8 +3,8 @@ import esphome.config_validation as cv
 from esphome import automation, pins
 from esphome.components import uart
 from esphome.const import (
-    CONF_ID,
     CONF_FLOW_CONTROL_PIN,
+    CONF_ID,
     CONF_SENSOR_DATAPOINT,
     CONF_TRIGGER_ID,
 )

--- a/components/econet/select/__init__.py
+++ b/components/econet/select/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import select
-from esphome.const import CONF_OPTIONS, CONF_ENUM_DATAPOINT
+from esphome.const import CONF_ENUM_DATAPOINT, CONF_OPTIONS
 
 from .. import (
     CONF_ECONET_ID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ check-filenames = ''
 [tool.ruff]
 fix = true
 show-fixes = true
-select = [
+
+[tool.ruff.lint]
+extend-select = [
+    "I", # Sorts imports
     "UP", # Replaces pyupgrade
 ]
 ignore = [


### PR DESCRIPTION
At some point (maybe always?) our ruff config ended up using `select` instead of  `extend-select` so it was skipping all of the default checks. I fixed that and ran a `pre-commit autoupdate` and `pre-commit run --all-files` to clean up anything missed.