### PR TITLE
HVAC zone control fix - add requestmod to enable sending control commands

### DIFF
--- a/hvac-zone-yaml/econet_hvac_zone_template.yaml
+++ b/hvac-zone-yaml/econet_hvac_zone_template.yaml
@@ -16,6 +16,7 @@ climate:
   - platform: econet
     id: zone${zonenumber}_climate
     name: ${zonename} Climate
+    request_mod: ${zone_thermostat_requestmod}
     src_address: ${zone_thermostat_address}
     visual:
       min_temperature: "10"
@@ -31,7 +32,9 @@ climate:
       2: "HEAT_COOL"
       3: "FAN_ONLY"
       4: "OFF"
-    custom_fan_mode_datapoint: STATNFAN
+    custom_fan_mode_datapoint: STAT_FAN
+    custom_fan_mode_no_schedule_datapoint: STATNFAN
+    follow_schedule_datapoint: SCHEDULE
     custom_fan_modes:
       0: "Automatic"
       1: "Speed 1 (Low)"


### PR DESCRIPTION
This enables direct control of zones (instead of read-only).

Known issue: single 'follow schedule' boolean is updated by every thermostat.   