### PR TITLE
Add configuration files for ESP32-C3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [esp32, esp32s3, esp8266]
+        platform: [esp32, esp32c3, esp32s3, esp8266]
         appliance:
           - name: electric_tank_water_heater
             shorthand: etwh

--- a/build-yaml/econet-etwh-esp32c3.yaml
+++ b/build-yaml/econet-etwh-esp32c3.yaml
@@ -1,0 +1,30 @@
+---
+substitutions:
+  tx_pin: GPIO21
+  rx_pin: GPIO20
+  board: esp32-c3-devkitm-1
+  platform: esp32
+  variant: esp32c3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_electric_tank_water_heater.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: ${variant}
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-hpwh-esp32c3.yaml
+++ b/build-yaml/econet-hpwh-esp32c3.yaml
@@ -1,0 +1,30 @@
+---
+substitutions:
+  tx_pin: GPIO21
+  rx_pin: GPIO20
+  board: esp32-c3-devkitm-1
+  platform: esp32
+  variant: esp32c3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_heatpump_water_heater.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: ${variant}
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-hvac_air_handler-esp32c3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32c3.yaml
@@ -1,0 +1,35 @@
+---
+substitutions:
+  tx_pin: GPIO21
+  rx_pin: GPIO20
+  board: esp32-c3-devkitm-1
+  platform: esp32
+  variant: esp32c3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_hvac_air_handler.yaml
+  # Uncomment if you have an communicating Outdoor Unit
+  # econet-hvac-odu:
+  #   url: https://github.com/esphome-econet/esphome-econet
+  #   ref: main
+  #   file: econet_hvac_odu.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: ${variant}
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-hvac_furnace-esp32c3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32c3.yaml
@@ -1,0 +1,35 @@
+---
+substitutions:
+  tx_pin: GPIO21
+  rx_pin: GPIO20
+  board: esp32-c3-devkitm-1
+  platform: esp32
+  variant: esp32c3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_hvac_furnace.yaml
+  # Uncomment if you have an communicating Outdoor Unit
+  # econet-hvac-odu:
+  #   url: https://github.com/esphome-econet/esphome-econet
+  #   ref: main
+  #   file: econet_hvac_odu.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: ${variant}
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password

--- a/build-yaml/econet-tlwh-esp32c3.yaml
+++ b/build-yaml/econet-tlwh-esp32c3.yaml
@@ -1,0 +1,30 @@
+---
+substitutions:
+  tx_pin: GPIO21
+  rx_pin: GPIO20
+  board: esp32-c3-devkitm-1
+  platform: esp32
+  variant: esp32c3
+
+packages:
+  econet:
+    url: https://github.com/esphome-econet/esphome-econet
+    ref: main
+    file: econet_tankless_water_heater.yaml
+
+dashboard_import:
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  import_full_config: false
+
+esphome:
+  platform: !remove
+  board: !remove
+
+esp32:
+  board: ${board}
+  variant: ${variant}
+
+# Uncomment the below to use Wi-Fi settings from your secrets.yaml file
+# wifi:
+#   ssid: !secret wifi_ssid
+#   password: !secret wifi_password


### PR DESCRIPTION
This adds the configuration files in `./build-yaml/` for compatibility with ESP32-C3. I have previously pieced together the YAML files for HPWH by hand and have had it working on an ESP32-C3 Super Mini for a few months. The proposed `./build-yaml/econet-hpwh-esp32c3.yaml` is confirmed working when installed through ESPHome.

The "Mode" sensor does not consistently update when on the ESP32-C3, but switching the `request_mod` for the sensor to `5` has resolved this bug.