### PR TITLE
Fix for #452 (Not building in esphome 2025.2.0) based on #422

### DIFF
--- a/build-yaml/econet-etwh-esp32c3.yaml
+++ b/build-yaml/econet-etwh-esp32c3.yaml
@@ -16,14 +16,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-etwh-esp32s3.yaml
+++ b/build-yaml/econet-etwh-esp32s3.yaml
@@ -16,14 +16,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-etwh-esp8266.yaml
+++ b/build-yaml/econet-etwh-esp8266.yaml
@@ -15,6 +15,10 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
 
+esp8266:
+  variant: !remove
+  framework: !remove
+
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hpwh-esp32c3.yaml
+++ b/build-yaml/econet-hpwh-esp32c3.yaml
@@ -16,14 +16,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hpwh-esp32s3.yaml
+++ b/build-yaml/econet-hpwh-esp32s3.yaml
@@ -16,14 +16,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hpwh-esp8266.yaml
+++ b/build-yaml/econet-hpwh-esp8266.yaml
@@ -15,6 +15,10 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
 
+esp8266:
+  variant: !remove
+  framework: !remove
+
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hvac_air_handler-esp32c3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32c3.yaml
@@ -21,14 +21,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hvac_air_handler-esp32s3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32s3.yaml
@@ -21,14 +21,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hvac_air_handler-esp8266.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp8266.yaml
@@ -20,6 +20,10 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
 
+esp8266:
+  variant: !remove
+  framework: !remove
+
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hvac_furnace-esp32c3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32c3.yaml
@@ -21,14 +21,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hvac_furnace-esp32s3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32s3.yaml
@@ -21,14 +21,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-hvac_furnace-esp8266.yaml
+++ b/build-yaml/econet-hvac_furnace-esp8266.yaml
@@ -20,6 +20,10 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
 
+esp8266:
+  variant: !remove
+  framework: !remove
+
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-tlwh-esp32c3.yaml
+++ b/build-yaml/econet-tlwh-esp32c3.yaml
@@ -16,14 +16,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-tlwh-esp32s3.yaml
+++ b/build-yaml/econet-tlwh-esp32s3.yaml
@@ -16,14 +16,6 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
   import_full_config: false
 
-esphome:
-  platform: !remove
-  board: !remove
-
-esp32:
-  board: ${board}
-  variant: ${variant}
-
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/build-yaml/econet-tlwh-esp8266.yaml
+++ b/build-yaml/econet-tlwh-esp8266.yaml
@@ -15,6 +15,10 @@ dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
 
+esp8266:
+  variant: !remove
+  framework: !remove
+
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:
 #   ssid: !secret wifi_ssid

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -25,10 +25,10 @@ esphome:
     name: "esphome-econet.esphome-econet"
     version: v2.3.0
 ${platform}:
-  board: $board
-  variant: $variant
+  board: ${board}
+  variant: ${variant}
   framework:
-    type: $framework
+    type: ${framework}
 preferences:
   flash_write_interval: "24h"
 wifi:

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -7,6 +7,8 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  variant: esp32
+  framework: arduino
   github_ref: main
   external_components_source: github://esphome-econet/esphome-econet@${github_ref}
   logger_level: WARN
@@ -19,11 +21,14 @@ esphome:
   friendly_name: ${friendly_name}
   comment: ${device_description}
   min_version: "2024.11.0"
-  platform: $platform
-  board: $board
   project:
     name: "esphome-econet.esphome-econet"
     version: v2.3.0
+${platform}:
+  board: $board
+  variant: $variant
+  framework:
+    type: $framework
 preferences:
   flash_write_interval: "24h"
 wifi:


### PR DESCRIPTION
This fixes #452 and is based on #422 with one difference (keeps the default type of arduino). Installed and tested on my ESP32 m5stack-atom against my HPWH.

Also updated all relevant build files and all build checks are passing.