### PR TITLE
Switching to use latest esphome beta for nightly build test

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -5,15 +5,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
-    inputs:
-      esphome-version:
-        type: choice
-        required: false
-        default: 'latest'
-        description: "Specify the esphome release with which to build."
-        options:
-          - latest
-          - beta
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -15,6 +15,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       force-verbose-logging: true
+      esphome-version: 'beta'
   create-issue-on-failure:
     name: Create Issue on Failure
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -5,6 +5,15 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      esphome-version:
+        type: choice
+        required: false
+        default: 'latest'
+        description: "Specify the esphome release with which to build."
+        options:
+          - latest
+          - beta
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ on:
         required: false
         default: 'latest'
         description: "Specify the esphome release with which to build."
-  
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,24 @@ on:
         required: false
         default: 'latest'
         description: "Specify the esphome release with which to build."
-
+  workflow_call:
+    inputs:
+      upload-artifacts:
+        type: boolean
+        required: false
+        default: false
+        description: "Set to true to have this workflow upload resulting firmware artifacts."
+      force-verbose-logging:
+        type: boolean
+        required: false
+        default: false
+        description: "Set to true to have this workflow force verbose logging, useful for catching build failures in logging code."
+      esphome-version:
+        type: string
+        required: false
+        default: 'latest'
+        description: "Specify the esphome release with which to build."
+  
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ on:
         required: false
         default: 'latest'
         description: "Specify the esphome release with which to build."
-  workflow_call:
+  workflow_dispatch:
     inputs:
       upload-artifacts:
         type: boolean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,11 @@ on:
         required: false
         default: false
         description: "Set to true to have this workflow force verbose logging, useful for catching build failures in logging code."
+      esphome-version:
+        type: string
+        required: false
+        default: 'latest'
+        description: "Specify the esphome release with which to build."
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -76,6 +81,7 @@ jobs:
         uses: esphome/build-action@v6
         with:
           yaml-file: build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
+          version: ${{ inputs.esphome-version }}
       - name: Copy firmware and manifest
         if: ${{ inputs.upload-artifacts }}
         run: |


### PR DESCRIPTION
This change would cause us to build the nightly build test with the most recent `beta` release of esphome if there is one newer than the `latest`; my hope is this would help us catch issues like #452.

Tested this change here: https://github.com/barndawgie/esphome-econet/actions/runs/13609468610