### PR TITLE
Add state_class to furnace and odu sensors to force number class, add stats

### DIFF
--- a/econet_hvac_furnace.yaml
+++ b/econet_hvac_furnace.yaml
@@ -147,7 +147,6 @@ sensor:
     name: "Furnace High Heat BTU Output"
     id: furnace_hh_btus
     sensor_datapoint: FURNHBTU
-    state_class: "measurement"
     entity_category: "diagnostic"
     unit_of_measurement: "btu/h"
     icon: "mdi:gas-burner"
@@ -156,7 +155,6 @@ sensor:
     name: "Furnace Low Heat BTU Output"
     id: furnace_lh_btus
     sensor_datapoint: FURNLBTU
-    state_class: "measurement"
     entity_category: "diagnostic"
     unit_of_measurement: "btu/h"
     icon: "mdi:gas-burner"

--- a/econet_hvac_furnace.yaml
+++ b/econet_hvac_furnace.yaml
@@ -122,6 +122,7 @@ sensor:
     name: "Flame Sensor"
     id: flame_sensor
     device_class: "current"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 4
     unit_of_measurement: "mA"
@@ -132,6 +133,7 @@ sensor:
     name: "Furnace AFUE"
     id: furnace_afue
     sensor_datapoint: FURNAFUE
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     unit_of_measurement: "%"
@@ -145,6 +147,7 @@ sensor:
     name: "Furnace High Heat BTU Output"
     id: furnace_hh_btus
     sensor_datapoint: FURNHBTU
+    state_class: "measurement"
     entity_category: "diagnostic"
     unit_of_measurement: "btu/h"
     icon: "mdi:gas-burner"
@@ -153,6 +156,7 @@ sensor:
     name: "Furnace Low Heat BTU Output"
     id: furnace_lh_btus
     sensor_datapoint: FURNLBTU
+    state_class: "measurement"
     entity_category: "diagnostic"
     unit_of_measurement: "btu/h"
     icon: "mdi:gas-burner"
@@ -161,6 +165,7 @@ sensor:
     name: "Two Week Cycles - Low Heat"
     id: low_heat_2week_cycles
     icon: "mdi:sync"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -169,6 +174,7 @@ sensor:
     name: "Two Week Cycles - High Heat"
     id: high_heat_2week_cycles
     icon: "mdi:sync"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -177,6 +183,7 @@ sensor:
     name: "Two Week Cycles - Blower"
     id: blower_2week_cycles
     icon: "mdi:sync"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -185,6 +192,7 @@ sensor:
     name: "Two Week Cycles - Powered"
     id: powered_2week_cycles
     icon: "mdi:sync"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -194,6 +202,7 @@ sensor:
     unit_of_measurement: "h"
     id: low_heat_2week_hrs
     icon: "mdi:timelapse"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -203,6 +212,7 @@ sensor:
     unit_of_measurement: "h"
     id: high_heat_2week_hrs
     icon: "mdi:timelapse"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -212,6 +222,7 @@ sensor:
     unit_of_measurement: "h"
     id: blower_2week_hrs
     icon: "mdi:timelapse"
+    state_class: "measurement"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -220,6 +231,7 @@ sensor:
     name: "Lifetime Cycles - Low Heat"
     id: low_heat_lifetime_cycles
     icon: "mdi:sync"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -228,6 +240,7 @@ sensor:
     name: "Lifetime Cycles - High Heat"
     id: high_heat_lifetime_cycles
     icon: "mdi:sync"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -236,6 +249,7 @@ sensor:
     name: "Lifetime Cycles - Blower"
     id: blower_lifetime_cycles
     icon: "mdi:sync"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -244,6 +258,7 @@ sensor:
     name: "Lifetime Cycles - Powered"
     id: powered_lifetime_cycles
     icon: "mdi:sync"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -253,6 +268,7 @@ sensor:
     unit_of_measurement: "h"
     id: low_heat_lifetime_hrs
     icon: "mdi:timelapse"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -262,6 +278,7 @@ sensor:
     unit_of_measurement: "h"
     id: high_heat_lifetime_hrs
     icon: "mdi:timelapse"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -271,6 +288,7 @@ sensor:
     unit_of_measurement: "h"
     id: blower_lifetime_hrs
     icon: "mdi:timelapse"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -280,6 +298,7 @@ sensor:
     unit_of_measurement: "d"
     id: powered_lifetime_days
     icon: "mdi:timelapse"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
     accuracy_decimals: 0
     filters:
@@ -289,6 +308,7 @@ sensor:
     id: instant_btu_output
     unit_of_measurement: "kbtu/h"
     icon: "mdi:gas-burner"
+    state_class: "measurement"
     accuracy_decimals: 3
     filters:
       - delta: 0.9
@@ -297,6 +317,7 @@ sensor:
     id: instant_btu_usage
     unit_of_measurement: "kbtu/h"
     icon: "mdi:gas-burner"
+    state_class: "measurement"
     accuracy_decimals: 3
     filters:
       - delta: 0.9
@@ -305,6 +326,7 @@ sensor:
     id: gas_usage_m3_h
     unit_of_measurement: "m³/h"
     icon: "mdi:meter-gas"
+    state_class: "measurement"
     accuracy_decimals: 3
   - platform: integration
     name: "Total Daily Gas"

--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -33,6 +33,7 @@ sensor:
     sensor_datapoint: ISCSPEED
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Pressure Liquid"
@@ -73,6 +74,7 @@ sensor:
     request_mod: none
     accuracy_decimals: 1
     unit_of_measurement: "%"
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Expansion Valve Super Heat"
@@ -121,6 +123,7 @@ sensor:
     unit_of_measurement: "s"
     request_mod: none
     accuracy_decimals: 0
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Cool Two Week Hours"
@@ -128,6 +131,7 @@ sensor:
     sensor_datapoint: ODURCS1H
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Cool Two Week Hours"
@@ -136,6 +140,7 @@ sensor:
     unit_of_measurement: ""
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Heat Two Week Hours"
@@ -143,6 +148,7 @@ sensor:
     sensor_datapoint: ODURHS1H
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Heat Two Week Hours"
@@ -150,6 +156,7 @@ sensor:
     sensor_datapoint: ODURHS2H
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Cool Two Week Cycles"
@@ -157,6 +164,7 @@ sensor:
     sensor_datapoint: ODURCS1C
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Cool Two Week Cycles"
@@ -164,6 +172,7 @@ sensor:
     sensor_datapoint: ODURCS2C
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Heat Two Week Cycles"
@@ -171,6 +180,7 @@ sensor:
     sensor_datapoint: ODURHS1C
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Heat Two Week Cycles"
@@ -178,6 +188,7 @@ sensor:
     sensor_datapoint: ODURHS2C
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Cool Lifetime Hours"
@@ -185,7 +196,7 @@ sensor:
     sensor_datapoint: ODULCS1H
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Cool Lifetime Hours"
@@ -193,7 +204,7 @@ sensor:
     sensor_datapoint: ODULCS2H
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Heat Lifetime Hours"
@@ -201,7 +212,7 @@ sensor:
     sensor_datapoint: ODULHS1H
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Heat Lifetime Hours"
@@ -209,7 +220,7 @@ sensor:
     sensor_datapoint: ODULHS2H
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Cool Lifetime Cycles"
@@ -217,7 +228,7 @@ sensor:
     sensor_datapoint: ODULCS1C
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Cool Lifetime Cycles"
@@ -225,7 +236,7 @@ sensor:
     sensor_datapoint: ODULCS2C
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Low Heat Lifetime Cycles"
@@ -233,7 +244,7 @@ sensor:
     sensor_datapoint: ODULHS1C
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU High Heat Lifetime Cycles"
@@ -241,7 +252,7 @@ sensor:
     sensor_datapoint: ODULHS2C
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Defrost Cycles Two Week Hours"
@@ -249,6 +260,7 @@ sensor:
     sensor_datapoint: ODURDEFC
     request_mod: none
     accuracy_decimals: 1
+    state_class: "measurement"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Defrost Cycles Lifetime Hours"
@@ -256,7 +268,7 @@ sensor:
     sensor_datapoint: ODULDEFC
     request_mod: none
     accuracy_decimals: 1
-    state_class: "total"
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU Days"
@@ -264,6 +276,7 @@ sensor:
     sensor_datapoint: ODU_DAYS
     request_mod: none
     accuracy_decimals: 1
+    state_class: "total_increasing"
     entity_category: "diagnostic"
   - platform: econet
     name: "ODU KW Hours"


### PR DESCRIPTION
Some of the values were showing as state instead of numbers in Home Assitant, which means there was no history graph, just history state changes. This both fixes that and adds long term statistics to everything