### PR TITLE
Switching to newer pre-commit alias.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.5


### PR DESCRIPTION
Ruff has moved to using `ruff-check` for the linter.