### PR TITLE
Set mcu_connected to true only when we receive a valid message

### DIFF
--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -175,6 +175,7 @@ class Econet : public Component, public uart::UARTDevice {
   uint32_t last_request_{0};
   uint32_t last_read_request_{0};
   uint32_t last_read_data_{0};
+  uint32_t last_valid_read_{0};
   std::vector<uint8_t> rx_message_;
   std::vector<uint8_t> tx_message_;
 


### PR DESCRIPTION
2nd attempt to fix #492

Move the code surrounding `mcu_connected_ = true` right after we get a valid message, i.e. right after the CRC check passed.