### PR TITLE
Reduce mcu_connected_timeout

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -15,7 +15,7 @@ substitutions:
   econet_update_interval: 30s
   econet_alarm_update_interval: 30s
   econet_alarm_history_update_interval: 60s
-  mcu_connected_timeout: 120s
+  mcu_connected_timeout: 40s
   wifi_module_address: "0x340"
 esphome:
   name: ${name}

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -15,7 +15,7 @@ substitutions:
   econet_update_interval: 30s
   econet_alarm_update_interval: 30s
   econet_alarm_history_update_interval: 60s
-  mcu_connected_timeout: 40s
+  mcu_connected_timeout: 30s
   wifi_module_address: "0x340"
 esphome:
   name: ${name}

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -15,7 +15,7 @@ substitutions:
   econet_update_interval: 30s
   econet_alarm_update_interval: 30s
   econet_alarm_history_update_interval: 60s
-  mcu_connected_timeout: 30s
+  mcu_connected_timeout: ${econet_update_interval}
   wifi_module_address: "0x340"
 esphome:
   name: ${name}


### PR DESCRIPTION
See https://github.com/esphome-econet/esphome-econet/issues/492#issuecomment-3037553344
Set it to mcu_connected_timeout =econet_update_interval in case anyone has increased econet_update_interval.
In the same base file we have up to `request_mod: 4` so 5 read requests spread every econet_update_interval (ignoring alarm history ones). Timing out at econet_update_interval means all 5 read requests failed.