### PR TITLE
fix(#501): Moving esp32 and esp8266 configs out of base configs

### DIFF
--- a/build-yaml/econet-etwh-esp32.yaml
+++ b/build-yaml/econet-etwh-esp32.yaml
@@ -4,6 +4,14 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  variant: esp32
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-etwh-esp32.yaml
+++ b/build-yaml/econet-etwh-esp32.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO19
   rx_pin: GPIO22
-  platform: esp32
+
+esp32:
   board: esp32dev
   variant: esp32
-  framework: arduino
-
-${platform}:
-  board: ${board}
-  variant: ${variant}
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-etwh-esp32c3.yaml
+++ b/build-yaml/econet-etwh-esp32c3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO21
   rx_pin: GPIO20
-  board: esp32-c3-devkitm-1
-  platform: esp32
-  variant: esp32c3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-c3-devkitm-1
+  variant: esp32c3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-etwh-esp32c3.yaml
+++ b/build-yaml/econet-etwh-esp32c3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-c3-devkitm-1
   platform: esp32
   variant: esp32c3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-etwh-esp32s3.yaml
+++ b/build-yaml/econet-etwh-esp32s3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
-  board: esp32-s3-devkitc-1
-  platform: esp32
-  variant: esp32s3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-etwh-esp32s3.yaml
+++ b/build-yaml/econet-etwh-esp32s3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-s3-devkitc-1
   platform: esp32
   variant: esp32s3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-etwh-esp8266.yaml
+++ b/build-yaml/econet-etwh-esp8266.yaml
@@ -2,11 +2,9 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
-  platform: esp8266
-  board: d1_mini
 
-${platform}:
-  board: ${board}
+esp8266:
+  board: d1_mini
 
 packages:
   econet:
@@ -15,7 +13,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-etwh-esp8266.yaml
+++ b/build-yaml/econet-etwh-esp8266.yaml
@@ -5,6 +5,9 @@ substitutions:
   platform: esp8266
   board: d1_mini
 
+${platform}:
+  board: ${board}
+
 packages:
   econet:
     url: https://github.com/esphome-econet/esphome-econet
@@ -14,10 +17,6 @@ packages:
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
-
-esp8266:
-  variant: !remove
-  framework: !remove
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hpwh-esp32.yaml
+++ b/build-yaml/econet-hpwh-esp32.yaml
@@ -4,6 +4,14 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  variant: esp32
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hpwh-esp32.yaml
+++ b/build-yaml/econet-hpwh-esp32.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO19
   rx_pin: GPIO22
-  platform: esp32
+
+esp32:
   board: esp32dev
   variant: esp32
-  framework: arduino
-
-${platform}:
-  board: ${board}
-  variant: ${variant}
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp32c3.yaml
+++ b/build-yaml/econet-hpwh-esp32c3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO21
   rx_pin: GPIO20
-  board: esp32-c3-devkitm-1
-  platform: esp32
-  variant: esp32c3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-c3-devkitm-1
+  variant: esp32c3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp32c3.yaml
+++ b/build-yaml/econet-hpwh-esp32c3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-c3-devkitm-1
   platform: esp32
   variant: esp32c3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hpwh-esp32s3.yaml
+++ b/build-yaml/econet-hpwh-esp32s3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
-  board: esp32-s3-devkitc-1
-  platform: esp32
-  variant: esp32s3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp32s3.yaml
+++ b/build-yaml/econet-hpwh-esp32s3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-s3-devkitc-1
   platform: esp32
   variant: esp32s3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hpwh-esp8266.yaml
+++ b/build-yaml/econet-hpwh-esp8266.yaml
@@ -2,11 +2,9 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
-  platform: esp8266
-  board: d1_mini
 
-${platform}:
-  board: ${board}
+esp8266:
+  board: d1_mini
 
 packages:
   econet:
@@ -15,7 +13,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp8266.yaml
+++ b/build-yaml/econet-hpwh-esp8266.yaml
@@ -5,6 +5,9 @@ substitutions:
   platform: esp8266
   board: d1_mini
 
+${platform}:
+  board: ${board}
+
 packages:
   econet:
     url: https://github.com/esphome-econet/esphome-econet
@@ -14,10 +17,6 @@ packages:
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
-
-esp8266:
-  variant: !remove
-  framework: !remove
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hvac_air_handler-esp32.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32.yaml
@@ -4,6 +4,14 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  variant: esp32
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_air_handler-esp32.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO19
   rx_pin: GPIO22
-  platform: esp32
+
+esp32:
   board: esp32dev
   variant: esp32
-  framework: arduino
-
-${platform}:
-  board: ${board}
-  variant: ${variant}
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -25,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_air_handler-esp32c3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32c3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-c3-devkitm-1
   platform: esp32
   variant: esp32c3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_air_handler-esp32c3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32c3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO21
   rx_pin: GPIO20
-  board: esp32-c3-devkitm-1
-  platform: esp32
-  variant: esp32c3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-c3-devkitm-1
+  variant: esp32c3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -25,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_air_handler-esp32s3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32s3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
-  board: esp32-s3-devkitc-1
-  platform: esp32
-  variant: esp32s3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -25,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_air_handler-esp32s3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32s3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-s3-devkitc-1
   platform: esp32
   variant: esp32s3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_air_handler-esp8266.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp8266.yaml
@@ -5,6 +5,9 @@ substitutions:
   platform: esp8266
   board: d1_mini
 
+${platform}:
+  board: ${board}
+
 packages:
   econet:
     url: https://github.com/esphome-econet/esphome-econet
@@ -19,10 +22,6 @@ packages:
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
-
-esp8266:
-  variant: !remove
-  framework: !remove
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hvac_air_handler-esp8266.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp8266.yaml
@@ -2,11 +2,9 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
-  platform: esp8266
-  board: d1_mini
 
-${platform}:
-  board: ${board}
+esp8266:
+  board: d1_mini
 
 packages:
   econet:
@@ -20,7 +18,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp32.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32.yaml
@@ -4,6 +4,14 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  variant: esp32
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_furnace-esp32.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO19
   rx_pin: GPIO22
-  platform: esp32
+
+esp32:
   board: esp32dev
   variant: esp32
-  framework: arduino
-
-${platform}:
-  board: ${board}
-  variant: ${variant}
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -25,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp32c3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32c3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-c3-devkitm-1
   platform: esp32
   variant: esp32c3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_furnace-esp32c3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32c3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO21
   rx_pin: GPIO20
-  board: esp32-c3-devkitm-1
-  platform: esp32
-  variant: esp32c3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-c3-devkitm-1
+  variant: esp32c3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -25,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp32s3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32s3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
-  board: esp32-s3-devkitc-1
-  platform: esp32
-  variant: esp32s3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -25,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp32s3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32s3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-s3-devkitc-1
   platform: esp32
   variant: esp32s3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_furnace-esp8266.yaml
+++ b/build-yaml/econet-hvac_furnace-esp8266.yaml
@@ -5,6 +5,9 @@ substitutions:
   platform: esp8266
   board: d1_mini
 
+${platform}:
+  board: ${board}
+
 packages:
   econet:
     url: https://github.com/esphome-econet/esphome-econet
@@ -19,10 +22,6 @@ packages:
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
-
-esp8266:
-  variant: !remove
-  framework: !remove
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/build-yaml/econet-hvac_furnace-esp8266.yaml
+++ b/build-yaml/econet-hvac_furnace-esp8266.yaml
@@ -2,11 +2,9 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
-  platform: esp8266
-  board: d1_mini
 
-${platform}:
-  board: ${board}
+esp8266:
+  board: d1_mini
 
 packages:
   econet:
@@ -20,7 +18,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp32.yaml
+++ b/build-yaml/econet-tlwh-esp32.yaml
@@ -4,6 +4,14 @@ substitutions:
   rx_pin: GPIO22
   platform: esp32
   board: esp32dev
+  variant: esp32
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-tlwh-esp32.yaml
+++ b/build-yaml/econet-tlwh-esp32.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO19
   rx_pin: GPIO22
-  platform: esp32
+
+esp32:
   board: esp32dev
   variant: esp32
-  framework: arduino
-
-${platform}:
-  board: ${board}
-  variant: ${variant}
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp32c3.yaml
+++ b/build-yaml/econet-tlwh-esp32c3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO21
   rx_pin: GPIO20
-  board: esp32-c3-devkitm-1
-  platform: esp32
-  variant: esp32c3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-c3-devkitm-1
+  variant: esp32c3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp32c3.yaml
+++ b/build-yaml/econet-tlwh-esp32c3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-c3-devkitm-1
   platform: esp32
   variant: esp32c3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-tlwh-esp32s3.yaml
+++ b/build-yaml/econet-tlwh-esp32s3.yaml
@@ -2,16 +2,12 @@
 substitutions:
   tx_pin: GPIO6
   rx_pin: GPIO5
-  board: esp32-s3-devkitc-1
-  platform: esp32
-  variant: esp32s3
-  framework: arduino
 
-${platform}:
-  board: ${board}
-  variant: ${variant}
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
   framework:
-    type: ${framework}
+    type: arduino
 
 packages:
   econet:
@@ -20,7 +16,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${variant}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp32s3.yaml
+++ b/build-yaml/econet-tlwh-esp32s3.yaml
@@ -5,6 +5,13 @@ substitutions:
   board: esp32-s3-devkitc-1
   platform: esp32
   variant: esp32s3
+  framework: arduino
+
+${platform}:
+  board: ${board}
+  variant: ${variant}
+  framework:
+    type: ${framework}
 
 packages:
   econet:

--- a/build-yaml/econet-tlwh-esp8266.yaml
+++ b/build-yaml/econet-tlwh-esp8266.yaml
@@ -2,11 +2,9 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
-  platform: esp8266
-  board: d1_mini
 
-${platform}:
-  board: ${board}
+esp8266:
+  board: d1_mini
 
 packages:
   econet:
@@ -15,7 +13,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp8266.yaml
+++ b/build-yaml/econet-tlwh-esp8266.yaml
@@ -5,6 +5,9 @@ substitutions:
   platform: esp8266
   board: d1_mini
 
+${platform}:
+  board: ${board}
+
 packages:
   econet:
     url: https://github.com/esphome-econet/esphome-econet
@@ -14,10 +17,6 @@ packages:
 dashboard_import:
   package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-${platform}.yaml@${github_ref}
   import_full_config: false
-
-esp8266:
-  variant: !remove
-  framework: !remove
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file
 # wifi:

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -25,11 +25,6 @@ esphome:
   project:
     name: "esphome-econet.esphome-econet"
     version: v2.9.2
-${platform}:
-  board: ${board}
-  variant: ${variant}
-  framework:
-    type: ${framework}
 preferences:
   flash_write_interval: "24h"
 wifi:


### PR DESCRIPTION
To solve #501, we need to move the platform configs out of the base as it is not longer supported to `!remove` some of the fields from them.

Per discussion with ESPHome folks in Discord, this shouldn't break existing configurations for folks, but there is some risk there.