### PR TITLE
ci: Build nightly from dev, beta, and release branches of esphome

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -12,10 +12,20 @@ concurrency:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        esphome-version:
+          - name: Release
+            shorthand: release
+          - name: Beta
+            shorthand: beta
+          - name: Development
+            shorthand: dev
+      fail-fast: false
     uses: ./.github/workflows/build.yml
     with:
       force-verbose-logging: true
-      esphome-version: 'beta'
+      esphome-version:  ${{ matrix.esphome-version.shorthand }}
   create-issue-on-failure:
     name: Create Issue on Failure
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       force-verbose-logging: true
-      esphome-version:  ${{ matrix.esphome-version.shorthand }}
+      esphome-version: ${{ matrix.esphome-version.shorthand }}
   create-issue-on-failure:
     name: Create Issue on Failure
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         esphome-version:
           - name: Release
-            shorthand: release
+            shorthand: latest
           - name: Beta
             shorthand: beta
           - name: Development

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ on:
         description: "Specify the esphome release with which to build."
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.esphome-version }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This change will run all three builds nightly and was recommended by the ESPHome devs to catch potential breaking changes even earlier in the cycle.

Tested here: https://github.com/barndawgie/esphome-econet/actions/runs/16212454046