### PR TITLE
Fix initialization of request_mod_last_requested_

### DIFF
--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -163,7 +163,7 @@ class Econet : public Component, public uart::UARTDevice {
   }
 
   std::vector<std::set<std::string>> request_datapoint_ids_ = std::vector<std::set<std::string>>(MAX_REQUEST_MODS);
-  std::vector<uint32_t> request_mod_last_requested_ = std::vector<uint32_t>{MAX_REQUEST_MODS, 0};
+  std::vector<uint32_t> request_mod_last_requested_ = std::vector<uint32_t>(MAX_REQUEST_MODS, 0);
   std::set<uint8_t> request_mods_;
   std::set<EconetDatapointID> raw_datapoint_ids_;
   std::set<EconetDatapointID> request_once_datapoint_ids_;


### PR DESCRIPTION
Old code was creating a std::vector with 2 elements: [16, 0]. New code correctly creates 16 elements all initialized to the value 0.
Old code was resulting in undefined behavior due to out-of-bounds access.