### PR TITLE
Optimize memory layout

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -227,7 +227,7 @@ void Econet::parse_message_(bool is_tx) {
           const std::string &datapoint_id = read_req_.obj_names[0];
           this->send_datapoint_(
               EconetDatapointID{.name = datapoint_id, .address = src_adr},
-              EconetDatapoint{.type = item_type, .value_float = 0, .value_string = "", .value_raw = raw});
+              EconetDatapoint{.value_raw = raw, .value_string = "", .value_float = 0, .type = item_type});
         }
       } else if (read_req_.type == 2) {
         // 1st pass to validate response and avoid any buffer over-read
@@ -321,7 +321,7 @@ void Econet::handle_response_(const EconetDatapointID &datapoint_id, const uint8
       ESP_LOGI(TAG, "  %s : %f", datapoint_id.name.c_str(), item_value);
       this->send_datapoint_(
           datapoint_id,
-          EconetDatapoint{.type = item_type, .value_float = item_value, .value_string = "", .value_raw = {}});
+          EconetDatapoint{.value_raw = {}, .value_string = "", .value_float = item_value, .type = item_type});
       break;
     }
     case EconetDatapointType::TEXT: {
@@ -330,7 +330,7 @@ void Econet::handle_response_(const EconetDatapointID &datapoint_id, const uint8
       std::string s = trim_trailing_whitespace((const char *) p, len);
       ESP_LOGI(TAG, "  %s : (%s)", datapoint_id.name.c_str(), s.c_str());
       this->send_datapoint_(datapoint_id,
-                            EconetDatapoint{.type = item_type, .value_float = 0, .value_string = s, .value_raw = {}});
+                            EconetDatapoint{.value_raw = {}, .value_string = s, .value_float = 0, .type = item_type});
       break;
     }
     case EconetDatapointType::ENUM_TEXT: {
@@ -350,7 +350,7 @@ void Econet::handle_response_(const EconetDatapointID &datapoint_id, const uint8
       ESP_LOGI(TAG, "  %s : %d (%s)", datapoint_id.name.c_str(), item_value, s.c_str());
       this->send_datapoint_(
           datapoint_id,
-          EconetDatapoint{.type = item_type, .value_enum = item_value, .value_string = s, .value_raw = {}});
+          EconetDatapoint{.value_raw = {}, .value_string = s, .value_enum = item_value, .type = item_type});
       break;
     }
     case EconetDatapointType::RAW:
@@ -359,7 +359,7 @@ void Econet::handle_response_(const EconetDatapointID &datapoint_id, const uint8
     case EconetDatapointType::UNSUPPORTED:
       ESP_LOGW(TAG, "  %s : UNSUPPORTED", datapoint_id.name.c_str());
       this->send_datapoint_(datapoint_id,
-                            EconetDatapoint{.type = item_type, .value_float = 0, .value_string = "", .value_raw = {}});
+                            EconetDatapoint{.value_raw = {}, .value_string = "", .value_float = 0, .type = item_type});
       break;
   }
 }
@@ -553,7 +553,7 @@ void Econet::set_float_datapoint_value(const std::string &datapoint_id, float va
   ESP_LOGD(TAG, "Setting datapoint %s to %f", datapoint_id.c_str(), value);
   this->set_datapoint_(
       EconetDatapointID{.name = datapoint_id, .address = address},
-      EconetDatapoint{.type = EconetDatapointType::FLOAT, .value_float = value, .value_string = "", .value_raw = {}});
+      EconetDatapoint{.value_raw = {}, .value_string = "", .value_float = value, .type = EconetDatapointType::FLOAT});
 }
 
 void Econet::set_enum_datapoint_value(const std::string &datapoint_id, uint8_t value, uint32_t address) {
@@ -561,7 +561,7 @@ void Econet::set_enum_datapoint_value(const std::string &datapoint_id, uint8_t v
   this->set_datapoint_(
       EconetDatapointID{.name = datapoint_id, .address = address},
       EconetDatapoint{
-          .type = EconetDatapointType::ENUM_TEXT, .value_enum = value, .value_string = "", .value_raw = {}});
+          .value_raw = {}, .value_string = "", .value_enum = value, .type = EconetDatapointType::ENUM_TEXT});
 }
 
 void Econet::set_datapoint_(const EconetDatapointID &datapoint_id, const EconetDatapoint &value) {
@@ -707,13 +707,13 @@ void Econet::homeassistant_read(const std::string &datapoint_id, uint32_t addres
 void Econet::homeassistant_write(const std::string &datapoint_id, uint8_t value, uint32_t address) {
   set_datapoint_(EconetDatapointID{.name = datapoint_id, .address = address},
                  EconetDatapoint{
-                     .type = EconetDatapointType::ENUM_TEXT, .value_enum = value, .value_string = "", .value_raw = {}});
+                     .value_raw = {}, .value_string = "", .value_enum = value, .type = EconetDatapointType::ENUM_TEXT});
 }
 
 void Econet::homeassistant_write(const std::string &datapoint_id, float value, uint32_t address) {
   set_datapoint_(
       EconetDatapointID{.name = datapoint_id, .address = address},
-      EconetDatapoint{.type = EconetDatapointType::FLOAT, .value_float = value, .value_string = "", .value_raw = {}});
+      EconetDatapoint{.value_raw = {}, .value_string = "", .value_float = value, .type = EconetDatapointType::FLOAT});
 }
 
 }  // namespace econet

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -13,6 +13,7 @@ namespace esphome {
 namespace econet {
 
 static const uint8_t MAX_REQUEST_MODS = 16;
+static const uint32_t DEFAULT_UPDATE_INTERVAL_MILLIS = 30000;
 
 class ReadRequest {
  public:
@@ -124,16 +125,16 @@ class Econet : public Component, public uart::UARTDevice {
   void homeassistant_write(const std::string &datapoint_id, float value, uint32_t address = 0);
 
  protected:
-  uint32_t update_interval_millis_{30000};
-  uint32_t mcu_connected_timeout_{120000};
+  uint32_t update_interval_millis_{DEFAULT_UPDATE_INTERVAL_MILLIS};
+  uint32_t mcu_connected_timeout_{DEFAULT_UPDATE_INTERVAL_MILLIS * 4};
   bool mcu_connected_{false};
   binary_sensor::BinarySensor *mcu_connected_binary_sensor_{nullptr};
   std::vector<uint32_t> request_mod_addresses_ = std::vector<uint32_t>(MAX_REQUEST_MODS, 0);
   std::map<uint8_t, uint32_t> request_mod_update_interval_millis_map_;
   std::vector<uint32_t> request_mod_update_interval_millis_ =
-      std::vector<uint32_t>(MAX_REQUEST_MODS, update_interval_millis_);
-  uint32_t min_update_interval_millis_{update_interval_millis_};
-  uint32_t min_delay_between_read_requests_{update_interval_millis_};
+      std::vector<uint32_t>(MAX_REQUEST_MODS, DEFAULT_UPDATE_INTERVAL_MILLIS);
+  uint32_t min_update_interval_millis_{DEFAULT_UPDATE_INTERVAL_MILLIS};
+  uint32_t min_delay_between_read_requests_{DEFAULT_UPDATE_INTERVAL_MILLIS};
 
   std::vector<EconetDatapointListener> listeners_;
   ReadRequest read_req_{};


### PR DESCRIPTION
Minimized Struct/Class Padding:
- The member variables within the Econet, ReadRequest, EconetDatapoint, and EconetClient classes have been reordered. Members are now grouped by size (from largest to smallest), which is a standard practice to reduce compiler-inserted padding and make the data structures more compact.
- Removed Unused Members:
The dst_bus and src_bus member variables have been removed from the ReadRequest class. since they were unused.
