### PR TITLE
Change AUTO mode to HEAT mode

### DIFF
--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -26,7 +26,7 @@ climate:
     mode_datapoint: WHTRENAB
     modes:
       0: "OFF"
-      1: "AUTO"
+      1: "HEAT"
     custom_preset_datapoint: WHTRCNFG
     custom_presets:
       0: "Energy Saver"


### PR DESCRIPTION
HomeAssistant 2025.10.0 doesn't display a temperature setting option if the device is in auto mode, which makes sense, since the mode is meant to describe the device dynamically changing the temperature. Water heaters can only heat up to a certain temperature, so to reflect that, change the mode to heat mode.

New UI:

<img width="548" height="581" alt="image" src="https://github.com/user-attachments/assets/0bef2dcd-46b5-4ab3-8e47-f8b74c8d6f13" />


Fixes #527.