### PR TITLE
fix: ESPHome 2026.1.0+ compatibility for custom presets and fan modes

### DIFF
--- a/components/econet/climate/econet_climate.h
+++ b/components/econet/climate/econet_climate.h
@@ -64,17 +64,14 @@ class EconetClimate : public climate::Climate, public Component, public EconetCl
   std::map<uint8_t, std::string> custom_presets_;
   std::map<uint8_t, std::string> custom_fan_modes_;
   // ESPHome 2026.1.0+ requires exact pointer matching for custom presets/fan modes.
-  // We store pointers from the stable map strings for use in traits() and listeners.
+  // std::map strings are stable once inserted, so we build pointer vectors once
+  // and use the same map entry pointers in listeners via find() + c_str().
   std::vector<const char *> custom_preset_ptrs_;
   std::vector<const char *> custom_fan_mode_ptrs_;
-  std::map<uint8_t, const char *> custom_preset_ptr_by_key_;
-  std::map<uint8_t, const char *> custom_fan_mode_ptr_by_key_;
-  bool ptrs_initialized_{false};
   std::string current_humidity_id_{""};
   std::string target_dehumidification_level_id_{""};
   void control(const climate::ClimateCall &call) override;
   climate::ClimateTraits traits() override;
-  void init_preset_ptrs_();
 };
 
 }  // namespace econet


### PR DESCRIPTION
Fixes #559

## Problem

ESPHome 2026.1.0 changed the Climate component to require exact pointer matching when calling `set_custom_preset_()` and `set_custom_fan_mode_()`. The internal validation now compares the passed pointer against the pointers registered in `traits()` using pointer equality, not string comparison.

This causes devices to crash and reboot on any mode/preset change with the error:
```
Preset mode is not valid
```

## Solution

- Store preset/fan mode pointers from stable `std::map` strings
- Create a key-to-pointer lookup map for each enum value
- Use the exact same pointer for `set_custom_preset_`/`set_custom_fan_mode_` that was registered in `traits()`

## Testing

Tested on ESP32 M5Stack Atom with heat pump water heater - presets now work correctly without crashes.

---
*AI-assisted: GitHub Copilot (Claude)*