### PR TITLE
Fix Econet climate component crashes by caching traits

### DIFF
--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -25,6 +25,9 @@ void EconetClimate::dump_config() {
 }
 
 climate::ClimateTraits EconetClimate::traits() {
+  if (traits_initialized_) {
+    return traits_;
+  }
   auto traits = climate::ClimateTraits();
   if (!current_temperature_id_.empty()) {
     traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
@@ -59,7 +62,9 @@ climate::ClimateTraits EconetClimate::traits() {
     }
     traits.set_supported_custom_fan_modes(fans);
   }
-  return traits;
+  traits_ = traits;
+  traits_initialized_ = true;
+  return traits_;
 }
 
 void EconetClimate::setup() {

--- a/components/econet/climate/econet_climate.h
+++ b/components/econet/climate/econet_climate.h
@@ -65,6 +65,8 @@ class EconetClimate : public climate::Climate, public Component, public EconetCl
   std::map<uint8_t, std::string> custom_fan_modes_;
   std::string current_humidity_id_{""};
   std::string target_dehumidification_level_id_{""};
+  climate::ClimateTraits traits_;
+  bool traits_initialized_{false};
   void control(const climate::ClimateCall &call) override;
   climate::ClimateTraits traits() override;
 };

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -21,7 +21,7 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   comment: ${device_description}
-  min_version: "2025.11.0"
+  min_version: "2026.1.0"
   project:
     name: "esphome-econet.esphome-econet"
     version: v3.2.0


### PR DESCRIPTION
- Cache ClimateTraits object in EconetClimate to eliminate overhead of rebuilding it on every call.
- Ensure pointer stability for custom presets and fan modes, preventing "Preset mode is not valid" errors during validation.
- Fixes #559