### PR TITLE
Optimize memory usage, performance, and safety

### DIFF
--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -146,7 +146,7 @@ void EconetClimate::setup() {
             ESP_LOGW(TAG, "In custom_presets of your yaml add: %d: \"%s\"", datapoint.value_enum,
                      datapoint.value_string.c_str());
           } else {
-            set_custom_preset_(it->second.c_str());
+            set_custom_preset_(it->second.c_str(), it->second.length());
             publish_state();
           }
         },

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -73,7 +73,7 @@ inline bool operator==(const EconetDatapoint &lhs, const EconetDatapoint &rhs) {
 
 struct EconetDatapointListener {
   EconetDatapointID datapoint_id;
-  std::function<void(EconetDatapoint)> on_datapoint;
+  std::function<void(const EconetDatapoint &)> on_datapoint;
 };
 
 class Econet : public Component, public uart::UARTDevice {
@@ -112,7 +112,7 @@ class Econet : public Component, public uart::UARTDevice {
   void set_enum_datapoint_value(const std::string &datapoint_id, uint8_t value, uint32_t address = 0);
 
   void register_listener(const std::string &datapoint_id, int8_t request_mod, bool request_once,
-                         const std::function<void(EconetDatapoint)> &func, bool is_raw_datapoint = false,
+                         const std::function<void(const EconetDatapoint &)> &func, bool is_raw_datapoint = false,
                          uint32_t src_adr = 0);
 
   void homeassistant_read(const std::string &datapoint_id, uint32_t address = 0);
@@ -164,6 +164,7 @@ class Econet : public Component, public uart::UARTDevice {
   std::queue<EconetDatapointID> datapoint_ids_for_read_service_;
   std::vector<uint8_t> rx_message_;
   std::vector<uint8_t> tx_message_;
+  std::vector<std::string> temp_objects_;
 
   // Pointers
   binary_sensor::BinarySensor *mcu_connected_binary_sensor_{nullptr};


### PR DESCRIPTION
- Reduce heap fragmentation by using reserved vectors and a reusable member for read requests.
- Eliminate unnecessary object copies by passing EconetDatapoint and other complex types via const reference in callbacks and internal methods.
- Optimize bytes_to_float using explicit bit shifts and memcpy for more efficient big-endian conversion, avoiding temporary stack arrays.
- Pass explicit string lengths to set_custom_preset_ and set_custom_fan_mode_ to avoid redundant strlen calls.
- Hoist string length calculations and other invariants out of loops in join_obj_names and write_value_ for better execution speed.
- Improve map efficiency in set_datapoint_, send_datapoint_, and register_listener by using find() and iterators to avoid redundant double lookups.
- Reduce temporary allocations by reusing EconetDatapointID objects where possible during listener registration.
- Replace non-standard Variable Length Arrays (VLA) in read_buffer_ with a fixed-size stack buffer for better standards compliance and safety.
- Refactor trim_trailing_whitespace to use pointer arithmetic and direct string construction, eliminating intermediate string copies.
- General C++ cleanup including consistent static_cast usage, loop optimizations, and removal of redundant code paths.