### PR TITLE
Refactor configuration to use singular add methods

### DIFF
--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -140,20 +140,13 @@ async def to_code(config):
     cg.add(var.set_dst_address(config[CONF_DST_ADDRESS]))
     if CONF_REQUEST_MOD_UPDATE_INTERVALS in config:
         request_mod_update_intervals = config[CONF_REQUEST_MOD_UPDATE_INTERVALS]
-        cg.add(
-            var.set_request_mod_update_intervals(
-                list(request_mod_update_intervals.keys()),
-                list(request_mod_update_intervals.values()),
-            )
-        )
+        cg.add(var.init_request_mod_update_intervals(len(request_mod_update_intervals)))
+        for mod, interval in request_mod_update_intervals.items():
+            cg.add(var.add_request_mod_update_interval(mod, interval))
     if CONF_REQUEST_MOD_ADDRESSES in config:
         request_mod_addresses = config[CONF_REQUEST_MOD_ADDRESSES]
-        cg.add(
-            var.set_request_mod_addresses(
-                list(request_mod_addresses.keys()),
-                list(request_mod_addresses.values()),
-            )
-        )
+        for mod, address in request_mod_addresses.items():
+            cg.add(var.add_request_mod_address(mod, address))
     if CONF_FLOW_CONTROL_PIN in config:
         pin = await gpio_pin_expression(config[CONF_FLOW_CONTROL_PIN])
         cg.add(var.set_flow_control_pin(pin))

--- a/components/econet/climate/__init__.py
+++ b/components/econet/climate/__init__.py
@@ -113,24 +113,21 @@ async def to_code(config):
         )
     )
     cg.add(var.set_follow_schedule_id(config[CONF_FOLLOW_SCHEDULE_DATAPOINT]))
-    cg.add(
-        var.set_modes(
-            list(config[CONF_MODES].keys()),
-            list(config[CONF_MODES].values()),
-        )
-    )
-    cg.add(
-        var.set_custom_presets(
-            list(config[CONF_CUSTOM_PRESETS].keys()),
-            list(config[CONF_CUSTOM_PRESETS].values()),
-        )
-    )
-    cg.add(
-        var.set_custom_fan_modes(
-            list(config[CONF_CUSTOM_FAN_MODES].keys()),
-            list(config[CONF_CUSTOM_FAN_MODES].values()),
-        )
-    )
+    if CONF_MODES in config:
+        modes = config[CONF_MODES]
+        cg.add(var.init_modes(len(modes)))
+        for key, value in modes.items():
+            cg.add(var.add_mode(key, value))
+    if CONF_CUSTOM_PRESETS in config:
+        presets = config[CONF_CUSTOM_PRESETS]
+        cg.add(var.init_custom_presets(len(presets)))
+        for key, value in presets.items():
+            cg.add(var.add_custom_preset(key, value))
+    if CONF_CUSTOM_FAN_MODES in config:
+        fan_modes = config[CONF_CUSTOM_FAN_MODES]
+        cg.add(var.init_custom_fan_modes(len(fan_modes)))
+        for key, value in fan_modes.items():
+            cg.add(var.add_custom_fan_mode(key, value))
     cg.add(var.set_current_humidity_id(config[CONF_CURRENT_HUMIDITY_DATAPOINT]))
     cg.add(
         var.set_target_dehumidification_level_id(

--- a/components/econet/climate/econet_climate.h
+++ b/components/econet/climate/econet_climate.h
@@ -5,7 +5,6 @@
 #include "../econet.h"
 #include "esphome/components/climate/climate.h"
 #include <string>
-#include <vector>
 
 namespace esphome {
 namespace econet {
@@ -33,33 +32,12 @@ class EconetClimate : public climate::Climate, public Component, public EconetCl
     this->custom_fan_mode_no_schedule_id_ = custom_fan_mode_no_schedule_id;
   }
   void set_follow_schedule_id(const std::string &follow_schedule_id) { this->follow_schedule_id_ = follow_schedule_id; }
-  void set_modes(const std::vector<uint8_t> &keys, const std::vector<climate::ClimateMode> &values) {
-    if (keys.size() != values.size()) {
-      return;
-    }
-    this->modes_.init(keys.size());
-    for (size_t i = 0; i < keys.size(); i++) {
-      this->modes_.push_back({keys[i], values[i]});
-    }
-  }
-  void set_custom_presets(const std::vector<uint8_t> &keys, const std::vector<std::string> &values) {
-    if (keys.size() != values.size()) {
-      return;
-    }
-    this->custom_presets_.init(keys.size());
-    for (size_t i = 0; i < keys.size(); i++) {
-      this->custom_presets_.push_back({keys[i], values[i]});
-    }
-  }
-  void set_custom_fan_modes(const std::vector<uint8_t> &keys, const std::vector<std::string> &values) {
-    if (keys.size() != values.size()) {
-      return;
-    }
-    this->custom_fan_modes_.init(keys.size());
-    for (size_t i = 0; i < keys.size(); i++) {
-      this->custom_fan_modes_.push_back({keys[i], values[i]});
-    }
-  }
+  void init_modes(size_t size) { this->modes_.init(size); }
+  void add_mode(uint8_t id, climate::ClimateMode mode) { this->modes_.push_back({id, mode}); }
+  void init_custom_presets(size_t size) { this->custom_presets_.init(size); }
+  void add_custom_preset(uint8_t id, const std::string &name) { this->custom_presets_.push_back({id, name}); }
+  void init_custom_fan_modes(size_t size) { this->custom_fan_modes_.init(size); }
+  void add_custom_fan_mode(uint8_t id, const std::string &name) { this->custom_fan_modes_.push_back({id, name}); }
   void set_current_humidity_id(const std::string &current_humidity_id) {
     this->current_humidity_id_ = current_humidity_id;
   }

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -91,19 +91,14 @@ class Econet : public Component, public uart::UARTDevice {
 
   void set_src_address(uint32_t address) { this->src_adr_ = address; }
   void set_dst_address(uint32_t address) { this->dst_adr_ = address; }
-  void set_request_mod_addresses(std::vector<uint8_t> request_mods, std::vector<uint32_t> addresses) {
-    for (auto i = 0; i < MAX_REQUEST_MODS; i++) {
-      this->request_mod_addresses_[i] = 0;
-    }
-    for (auto i = 0; i < request_mods.size(); i++) {
-      this->request_mod_addresses_[request_mods[i]] = addresses[i];
+  void add_request_mod_address(uint8_t mod, uint32_t address) {
+    if (mod < MAX_REQUEST_MODS) {
+      this->request_mod_addresses_[mod] = address;
     }
   }
-  void set_request_mod_update_intervals(std::vector<uint8_t> request_mods, std::vector<uint32_t> update_intervals) {
-    this->request_mod_update_interval_millis_map_.init(request_mods.size());
-    for (size_t i = 0; i < request_mods.size(); i++) {
-      this->request_mod_update_interval_millis_map_.push_back({request_mods[i], update_intervals[i]});
-    }
+  void init_request_mod_update_intervals(size_t size) { this->request_mod_update_interval_millis_map_.init(size); }
+  void add_request_mod_update_interval(uint8_t mod, uint32_t interval) {
+    this->request_mod_update_interval_millis_map_.push_back({mod, interval});
     this->update_intervals_();
   }
   void set_update_interval(uint32_t interval_millis) {

--- a/components/econet/select/__init__.py
+++ b/components/econet/select/__init__.py
@@ -48,7 +48,9 @@ async def to_code(config):
     options_map = config[CONF_OPTIONS]
     var = await select.new_select(config, options=list(options_map.values()))
     await cg.register_component(var, config)
-    cg.add(var.set_select_mappings(list(options_map.keys())))
+    cg.add(var.init_select_mappings(len(options_map)))
+    for key in options_map.keys():
+        cg.add(var.add_select_mapping(key))
     paren = await cg.get_variable(config[CONF_ECONET_ID])
     cg.add(var.set_econet_parent(paren))
     cg.add(var.set_request_mod(config[CONF_REQUEST_MOD]))

--- a/components/econet/select/econet_select.h
+++ b/components/econet/select/econet_select.h
@@ -14,7 +14,8 @@ class EconetSelect : public select::Select, public Component, public EconetClien
   void setup() override;
   void dump_config() override;
   void set_select_id(const std::string &select_id) { this->select_id_ = select_id; }
-  void set_select_mappings(std::vector<uint8_t> mappings) { this->mappings_ = std::move(mappings); }
+  void init_select_mappings(size_t size) { this->mappings_.reserve(size); }
+  void add_select_mapping(uint8_t mapping) { this->mappings_.push_back(mapping); }
 
  protected:
   void control(const std::string &value) override;


### PR DESCRIPTION
Optimize initialization by removing std::vector from C++ function signatures in favor of a "Repeated Add" pattern from Python:

- Replace methods accepting std::vector with init/add pairs across Econet, EconetClimate, and EconetSelect components.
- Reduce Flash bloat by eliminating STL vector template instantiations in to_code generated calls.
- Prevent heap peaks during boot by eliminating temporary vectors used only for initialization.
- Align FixedVector usage with ESPHome best practices (init size then push_back).