### PR TITLE
Optimize mappings container using FixedVector

### DIFF
--- a/components/econet/select/econet_select.cpp
+++ b/components/econet/select/econet_select.cpp
@@ -12,13 +12,13 @@ void EconetSelect::setup() {
       [this](const EconetDatapoint &datapoint) {
         uint8_t enum_value = datapoint.value_enum;
         ESP_LOGV(TAG, "MCU reported select %s value %u", this->select_id_.c_str(), enum_value);
-        auto mappings = this->mappings_;
-        auto it = std::find(mappings.cbegin(), mappings.cend(), enum_value);
-        if (it == mappings.cend()) {
+        const auto &mappings = this->mappings_;
+        auto it = std::find(mappings.begin(), mappings.end(), enum_value);
+        if (it == mappings.end()) {
           ESP_LOGW(TAG, "Invalid value %u", enum_value);
           return;
         }
-        size_t mapping_idx = std::distance(mappings.cbegin(), it);
+        size_t mapping_idx = std::distance(mappings.begin(), it);
         auto value = this->at(mapping_idx);
         this->publish_state(value.value());
       },
@@ -28,7 +28,7 @@ void EconetSelect::setup() {
 void EconetSelect::control(const std::string &value) {
   auto idx = this->index_of(value);
   if (idx.has_value()) {
-    uint8_t mapping = this->mappings_.at(idx.value());
+    uint8_t mapping = this->mappings_[idx.value()];
     ESP_LOGV(TAG, "Setting %s datapoint value to %u:%s", this->select_id_.c_str(), mapping, value.c_str());
     this->parent_->set_enum_datapoint_value(this->select_id_, mapping, this->src_adr_);
     return;
@@ -42,7 +42,7 @@ void EconetSelect::dump_config() {
   ESP_LOGCONFIG(TAG, "  Options are:");
   const auto &options = this->traits.get_options();
   for (size_t i = 0; i < this->mappings_.size(); i++) {
-    ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_.at(i), options.at(i));
+    ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_[i], options.at(i));
   }
 }
 

--- a/components/econet/select/econet_select.h
+++ b/components/econet/select/econet_select.h
@@ -2,9 +2,8 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/select/select.h"
+#include "esphome/core/helpers.h"
 #include "../econet.h"
-
-#include <vector>
 
 namespace esphome {
 namespace econet {
@@ -14,14 +13,14 @@ class EconetSelect : public select::Select, public Component, public EconetClien
   void setup() override;
   void dump_config() override;
   void set_select_id(const std::string &select_id) { this->select_id_ = select_id; }
-  void init_select_mappings(size_t size) { this->mappings_.reserve(size); }
+  void init_select_mappings(size_t size) { this->mappings_.init(size); }
   void add_select_mapping(uint8_t mapping) { this->mappings_.push_back(mapping); }
 
  protected:
   void control(const std::string &value) override;
 
   std::string select_id_{""};
-  std::vector<uint8_t> mappings_;
+  FixedVector<uint8_t> mappings_;
 };
 
 }  // namespace econet


### PR DESCRIPTION
Replace std::vector with FixedVector for select option mappings:
- Use FixedVector in EconetSelect for runtime-initialized mappings.
- Eliminate dynamic reallocation logic for mappings with run-time fixed sizes.
- Refactor accessors to use operator[] and references, avoiding unnecessary container copies.
- Cleanup includes by removing <vector> from the header.