### PR TITLE
Refactor HA read to synchronous actions [BREAKING CHANGE]

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -31,39 +31,50 @@ wifi:
   ap:
 captive_portal:
 api:
-  homeassistant_services: true
-  services:
-    - service: read
+  actions:
+    - action: read
       variables:
         datapoint_id: string
+      supports_response: only
       then:
-        - lambda: id(econet_id).homeassistant_read(datapoint_id);
-    - service: read_from_address
+        - api.respond:
+            data: !lambda |-
+              std::map<std::string, std::string> result = id(econet_id).homeassistant_read(datapoint_id);
+              for (auto const& item : result) {
+                root[item.first] = item.second;
+              }
+    - action: read_from_address
       variables:
         datapoint_id: string
         address: int
+      supports_response: only
       then:
-        - lambda: id(econet_id).homeassistant_read(datapoint_id, address);
-    - service: write_enum
+        - api.respond:
+            data: !lambda |-
+              std::map<std::string, std::string> result = id(econet_id).homeassistant_read(datapoint_id, address);
+              for (auto const& item : result) {
+                root[item.first] = item.second;
+              }
+    - action: write_enum
       variables:
         datapoint_id: string
         value: int
       then:
         - lambda: id(econet_id).homeassistant_write(datapoint_id, (uint8_t) value);
-    - service: write_enum_from_address
+    - action: write_enum_from_address
       variables:
         datapoint_id: string
         value: int
         address: int
       then:
         - lambda: id(econet_id).homeassistant_write(datapoint_id, (uint8_t) value, address);
-    - service: write_float
+    - action: write_float
       variables:
         datapoint_id: string
         value: float
       then:
         - lambda: id(econet_id).homeassistant_write(datapoint_id, value);
-    - service: write_float_from_address
+    - action: write_float_from_address
       variables:
         datapoint_id: string
         value: float


### PR DESCRIPTION
Migrates the Home Assistant read integration from firing asynchronous events (`esphome.econet_event`) to returning synchronous responses directly to the calling Action.

Changes:
- Updates `homeassistant_read` to block (while feeding WDT) until a response is received or a timeout occurs.
- Returns a `std::map` with full datapoint details (type, value, raw, etc.) matching the previous event structure.
- Adds "one-shot" listener support to `Econet::register_listener` to fix memory leaks where repeated service calls would permanently accumulate callbacks.
- Removes `USE_API_HOMEASSISTANT_SERVICES` and `CustomAPIDevice` dependencies.
- Updates YAML configuration to use `api.respond` and `supports_response: only`.

BREAKING CHANGE:
The `esphome.econet_event` event is no longer fired. Home Assistant automations relying on this event trigger must be updated to call the action (service) and capture the result using `response_variable`.