### PR TITLE
Add water heater entity

### DIFF
--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -4,9 +4,13 @@ substitutions:
   friendly_name: "Water Heater"
   device_description: "Rheem Electric Tank Water Heater"
   sensor_power_filters_lambda: return x;
+  water_heater_eco_preset: "Energy Saver"
+  water_heater_off_preset: "None"
+  water_heater_default_mode: "water_heater::WATER_HEATER_MODE_PERFORMANCE"
 
 packages:
   econet: !include econet_base.yaml
+  water_heater: !include econet_water_heater_base.yaml
 
 econet:
   dst_address: 0x1200
@@ -15,6 +19,7 @@ climate:
   - platform: econet
     id: econet_climate
     name: None
+    disabled_by_default: true
     visual:
       min_temperature: "110 °F"
       max_temperature: "140 °F"
@@ -29,8 +34,15 @@ climate:
       1: "HEAT"
     custom_preset_datapoint: WHTRCNFG
     custom_presets:
-      0: "Energy Saver"
+      0: "${water_heater_eco_preset}"
       1: "Performance"
+
+water_heater:
+  - id: !extend econet_water_heater
+    supported_modes:
+      - "OFF"
+      - ECO
+      - PERFORMANCE
 
 sensor:
   - platform: econet

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -3,6 +3,9 @@ substitutions:
   name: "econet-hpwh"
   friendly_name: "Water Heater"
   device_description: "Rheem Heat Pump Water Heater"
+  water_heater_eco_preset: "Eco Mode"
+  water_heater_off_preset: "Off"
+  water_heater_default_mode: "water_heater::WATER_HEATER_MODE_HEAT_PUMP"
 
 packages:
   econet: !include econet_electric_tank_water_heater.yaml
@@ -13,13 +16,22 @@ econet:
 climate:
   - id: !extend econet_climate
     custom_presets:
-      0: "Off"
-      1: "Eco Mode"
+      0: "${water_heater_off_preset}"
+      1: "${water_heater_eco_preset}"
       2: "Heat Pump"
       3: "High Demand"
       4: "Electric"
       # Vacation preset doesn't seem to have any effect
       # 5: "Vacation"
+
+water_heater:
+  - id: !extend econet_water_heater
+    supported_modes:
+      - "OFF"
+      - ECO
+      - HEAT_PUMP
+      - HIGH_DEMAND
+      - ELECTRIC
 
 sensor:
   - platform: econet

--- a/econet_tankless_water_heater.yaml
+++ b/econet_tankless_water_heater.yaml
@@ -5,9 +5,13 @@ substitutions:
   device_description: "Rheem Tankless Water Heater"
   econet_update_interval: 5s
   tankless_kbtus_per_m3: "35.300"  # Natural Gas = approx 35.300, Propane = approx 88.852
+  water_heater_eco_preset: "None"
+  water_heater_off_preset: "None"
+  water_heater_default_mode: "water_heater::WATER_HEATER_MODE_GAS"
 
 packages:
   econet: !include econet_base.yaml
+  water_heater: !include econet_water_heater_base.yaml
 
 econet:
   dst_address: 0x1040
@@ -16,6 +20,7 @@ climate:
   - platform: econet
     id: econet_climate
     name: None
+    disabled_by_default: true
     visual:
       min_temperature: "110 °F"
       max_temperature: "140 °F"
@@ -28,6 +33,12 @@ climate:
     modes:
       0: "OFF"
       1: "HEAT"
+
+water_heater:
+  - id: !extend econet_water_heater
+    supported_modes:
+      - "OFF"
+      - GAS
 
 sensor:
   - platform: econet

--- a/econet_water_heater_base.yaml
+++ b/econet_water_heater_base.yaml
@@ -1,0 +1,83 @@
+---
+water_heater:
+  - platform: template
+    id: econet_water_heater
+    name: None
+    visual:
+      min_temperature: "110 °F"
+      max_temperature: "140 °F"
+      target_temperature_step: 1
+    current_temperature: |-
+      float val = id(econet_climate).current_temperature;
+      // Synchronization hack: Update the internal state of the water heater
+      // to match the climate component. This bypasses the lack of a target_temperature lambda.
+      auto *wh = id(econet_water_heater);
+      float target = id(econet_climate).target_temperature;
+      if (!std::isnan(target) && wh->get_target_temperature() != target) {
+        struct WaterHeaterAccessor : public water_heater::WaterHeater {
+          using water_heater::WaterHeater::target_temperature_;
+        };
+        static_cast<WaterHeaterAccessor *>(static_cast<water_heater::WaterHeater *>(wh))->target_temperature_ = target;
+        wh->publish_state();
+      }
+      return val;
+    # TODO: Once https://github.com/esphome/esphome/pull/13661 is released, replace the hack with:
+    # current_temperature: !lambda "return id(econet_climate).current_temperature;"
+    # target_temperature: !lambda "return id(econet_climate).target_temperature;"
+    mode: |-
+      if (id(econet_climate).mode == climate::CLIMATE_MODE_OFF) {
+        return water_heater::WATER_HEATER_MODE_OFF;
+      }
+      if (id(econet_climate).has_custom_preset()) {
+        auto preset = id(econet_climate).get_custom_preset();
+        if (preset == "Energy Saver" || preset == "Eco Mode") {
+          return water_heater::WATER_HEATER_MODE_ECO;
+        }
+        if (preset == "Performance") {
+          return water_heater::WATER_HEATER_MODE_PERFORMANCE;
+        }
+        if (preset == "Heat Pump") {
+          return water_heater::WATER_HEATER_MODE_HEAT_PUMP;
+        }
+        if (preset == "High Demand") {
+          return water_heater::WATER_HEATER_MODE_HIGH_DEMAND;
+        }
+        if (preset == "Electric") {
+          return water_heater::WATER_HEATER_MODE_ELECTRIC;
+        }
+        if (preset == "${water_heater_off_preset}") {
+          return water_heater::WATER_HEATER_MODE_OFF;
+        }
+      }
+      return ${water_heater_default_mode};
+    set_action:
+      - climate.control:
+          id: econet_climate
+          target_temperature: !lambda "return id(econet_water_heater).get_target_temperature();"
+          mode: !lambda |-
+            auto op_mode = id(econet_water_heater).get_mode();
+            if (op_mode == water_heater::WATER_HEATER_MODE_OFF) {
+              return climate::CLIMATE_MODE_OFF;
+            }
+            return climate::CLIMATE_MODE_HEAT;
+          custom_preset: !lambda |-
+            auto op_mode = id(econet_water_heater).get_mode();
+            if (op_mode == water_heater::WATER_HEATER_MODE_ECO) {
+              return {"${water_heater_eco_preset}"};
+            }
+            if (op_mode == water_heater::WATER_HEATER_MODE_PERFORMANCE) {
+              return {"Performance"};
+            }
+            if (op_mode == water_heater::WATER_HEATER_MODE_HEAT_PUMP) {
+              return {"Heat Pump"};
+            }
+            if (op_mode == water_heater::WATER_HEATER_MODE_HIGH_DEMAND) {
+              return {"High Demand"};
+            }
+            if (op_mode == water_heater::WATER_HEATER_MODE_ELECTRIC) {
+              return {"Electric"};
+            }
+            if (op_mode == water_heater::WATER_HEATER_MODE_OFF) {
+              return {"${water_heater_off_preset}"};
+            }
+            return {};


### PR DESCRIPTION
Fixes https://github.com/esphome-econet/esphome-econet/issues/560
Until https://github.com/esphome/esphome/pull/13661 is merged and released there is a hack for target temperature to work.
Requires Home Assistant 2026.2.0 so this should be merged after that is released.
To avoid a breaking change, the climate entity is not marked as internal. Instead it's `disabled_by_default`. For existing installations the climate entity remains enabled and no automations will break. Users will have to manually migrate to using the water heater entity.