### PR TITLE
Switch to esp-idf

### DIFF
--- a/build-yaml/econet-etwh-esp32.yaml
+++ b/build-yaml/econet-etwh-esp32.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32dev
   variant: esp32
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-etwh-esp32c3.yaml
+++ b/build-yaml/econet-etwh-esp32c3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-c3-devkitm-1
   variant: esp32c3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-etwh-esp32s3.yaml
+++ b/build-yaml/econet-etwh-esp32s3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hpwh-esp32.yaml
+++ b/build-yaml/econet-hpwh-esp32.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32dev
   variant: esp32
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hpwh-esp32c3.yaml
+++ b/build-yaml/econet-hpwh-esp32c3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-c3-devkitm-1
   variant: esp32c3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hpwh-esp32s3.yaml
+++ b/build-yaml/econet-hpwh-esp32s3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_air_handler-esp32.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32dev
   variant: esp32
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_air_handler-esp32c3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32c3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-c3-devkitm-1
   variant: esp32c3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_air_handler-esp32s3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32s3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_furnace-esp32.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32dev
   variant: esp32
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_furnace-esp32c3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32c3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-c3-devkitm-1
   variant: esp32c3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-hvac_furnace-esp32s3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32s3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-tlwh-esp32.yaml
+++ b/build-yaml/econet-tlwh-esp32.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32dev
   variant: esp32
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-tlwh-esp32c3.yaml
+++ b/build-yaml/econet-tlwh-esp32c3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-c3-devkitm-1
   variant: esp32c3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/build-yaml/econet-tlwh-esp32s3.yaml
+++ b/build-yaml/econet-tlwh-esp32s3.yaml
@@ -7,7 +7,7 @@ esp32:
   board: esp32-s3-devkitc-1
   variant: esp32s3
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:
   econet:

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -5,10 +5,6 @@ substitutions:
   device_description: "Rheem Device"
   tx_pin: GPIO19
   rx_pin: GPIO22
-  platform: esp32
-  board: esp32dev
-  variant: esp32
-  framework: arduino
   github_ref: main
   external_components_source: github://esphome-econet/esphome-econet@${github_ref}
   logger_level: WARN

--- a/example-local.yaml
+++ b/example-local.yaml
@@ -14,7 +14,7 @@ esp32:
   board: esp32dev
   variant: esp32
   framework:
-    type: arduino
+    type: esp-idf
 
 packages:  # Change this file to the correct one(s) for your device
   econet-hpwh: !include econet_heatpump_water_heater.yaml


### PR DESCRIPTION
- Since ESPHome 2026.1 esp-idf is the default for ESP32, delivering smaller binaries and faster compile times.
- Removed unused substitutions in `econet_base.yaml`.