### PR TITLE
fix: migrate climate custom modes to entity setters (ESPHome 2026.4.0)

### DIFF
--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -4,6 +4,8 @@
 #include "esphome/components/climate/climate_traits.h"
 #include "econet_climate.h"
 #include <algorithm>
+#include <string>
+#include <vector>
 
 using namespace esphome;
 
@@ -45,22 +47,6 @@ climate::ClimateTraits EconetClimate::traits() {
     for (const auto &entry : this->modes_) {
       traits.add_supported_mode(entry.mode);
     }
-  }
-  if (this->custom_preset_id_ && *this->custom_preset_id_) {
-    std::vector<const char *> presets;
-    presets.reserve(this->custom_presets_.size());
-    for (const auto &entry : this->custom_presets_) {
-      presets.push_back(entry.name);
-    }
-    traits.set_supported_custom_presets(presets);
-  }
-  if (this->custom_fan_mode_id_ && *this->custom_fan_mode_id_) {
-    std::vector<const char *> fans;
-    fans.reserve(this->custom_fan_modes_.size());
-    for (const auto &entry : this->custom_fan_modes_) {
-      fans.push_back(entry.name);
-    }
-    traits.set_supported_custom_fan_modes(fans);
   }
   this->traits_ = traits;
   this->traits_initialized_ = true;
@@ -109,6 +95,23 @@ void EconetClimate::register_fan_listener(const char *id, std::string *member, b
 }
 
 void EconetClimate::setup() {
+  if (this->custom_preset_id_ && *this->custom_preset_id_) {
+    std::vector<const char *> presets;
+    presets.reserve(this->custom_presets_.size());
+    for (const auto &entry : this->custom_presets_) {
+      presets.push_back(entry.name);
+    }
+    this->set_supported_custom_presets(presets);
+  }
+  if (this->custom_fan_mode_id_ && *this->custom_fan_mode_id_) {
+    std::vector<const char *> fans;
+    fans.reserve(this->custom_fan_modes_.size());
+    for (const auto &entry : this->custom_fan_modes_) {
+      fans.push_back(entry.name);
+    }
+    this->set_supported_custom_fan_modes(fans);
+  }
+
   this->register_float_listener(this->current_temperature_id_, &this->current_temperature, true);
   this->register_float_listener(this->target_temperature_id_, &this->target_temperature, true);
   this->register_float_listener(this->target_temperature_low_id_, &this->target_temperature_low, true);

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${name}
   friendly_name: ${friendly_name}
   comment: ${device_description}
-  min_version: "2026.2.0"
+  min_version: "2026.4.0"
   project:
     name: "esphome-econet.esphome-econet"
     version: v3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome>=2025.11.0
+esphome>=2026.4.0
 pre-commit>=3.7.0


### PR DESCRIPTION
ClimateTraits::set_supported_custom_fan_modes() and set_supported_custom_presets() are deprecated in ESPHome 2026.4.0.

Move the vector setup from traits() into setup(), calling the new entity-level this->set_supported_custom_fan_modes() and this->set_supported_custom_presets() methods once at startup instead of rebuilding and heap-allocating on every traits() call.

Fixes #596