### PR TITLE
Add support for turn on/off and away

### DIFF
--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -7,6 +7,9 @@ substitutions:
   water_heater_eco_preset: "Energy Saver"
   water_heater_off_preset: "None"
   water_heater_default_mode: "water_heater::WATER_HEATER_MODE_PERFORMANCE"
+  water_heater_default_mode_preset: "Performance"
+  # yamllint disable-line rule:line-length
+  water_heater_set_away_code: 'auto call = id(vaca_net).make_call(); call.set_option(id(econet_water_heater).is_away() ? "Permanent" : "Off"); call.perform();'
 
 packages:
   econet: !include econet_base.yaml
@@ -43,6 +46,8 @@ water_heater:
       - "OFF"
       - ECO
       - PERFORMANCE
+    away: !lambda |-
+      return id(vaca_net).current_option() == "Permanent";
 
 sensor:
   - platform: econet
@@ -104,6 +109,8 @@ select:
   - platform: "econet"
     name: "Vacation"
     id: vaca_net
+    # TODO: Uncomment once https://github.com/home-assistant/core/pull/167951 is released
+    # disabled_by_default: true
     enum_datapoint: VACA_NET
     options:
       0: "Off"

--- a/econet_heatpump_water_heater.yaml
+++ b/econet_heatpump_water_heater.yaml
@@ -6,6 +6,7 @@ substitutions:
   water_heater_eco_preset: "Eco Mode"
   water_heater_off_preset: "Off"
   water_heater_default_mode: "water_heater::WATER_HEATER_MODE_HEAT_PUMP"
+  water_heater_default_mode_preset: "Heat Pump"
 
 packages:
   econet: !include econet_electric_tank_water_heater.yaml

--- a/econet_tankless_water_heater.yaml
+++ b/econet_tankless_water_heater.yaml
@@ -7,7 +7,9 @@ substitutions:
   tankless_kbtus_per_m3: "35.300"  # Natural Gas = approx 35.300, Propane = approx 88.852
   water_heater_eco_preset: "None"
   water_heater_off_preset: "None"
+  water_heater_default_mode_preset: "None"
   water_heater_default_mode: "water_heater::WATER_HEATER_MODE_GAS"
+  water_heater_set_away_code: "// no-op"
 
 packages:
   econet: !include econet_base.yaml

--- a/econet_water_heater_base.yaml
+++ b/econet_water_heater_base.yaml
@@ -1,4 +1,10 @@
 ---
+globals:
+  - id: wh_last_active_preset
+    type: std::string
+    restore_value: true
+    initial_value: '"${water_heater_default_mode_preset}"'
+
 water_heater:
   - platform: template
     id: econet_water_heater
@@ -9,6 +15,16 @@ water_heater:
       target_temperature_step: 1
     current_temperature: !lambda "return id(econet_climate).current_temperature;"
     target_temperature: !lambda "return id(econet_climate).target_temperature;"
+    is_on: !lambda |-
+      if (id(econet_climate).mode == climate::CLIMATE_MODE_OFF) {
+        return false;
+      }
+      if (id(econet_climate).has_custom_preset()) {
+        if (id(econet_climate).get_custom_preset() == "${water_heater_off_preset}") {
+          return false;
+        }
+      }
+      return true;
     mode: |-
       if (id(econet_climate).mode == climate::CLIMATE_MODE_OFF) {
         return water_heater::WATER_HEATER_MODE_OFF;
@@ -40,29 +56,73 @@ water_heater:
           id: econet_climate
           target_temperature: !lambda "return id(econet_water_heater).get_target_temperature();"
           mode: !lambda |-
-            auto op_mode = id(econet_water_heater).get_mode();
-            if (op_mode == water_heater::WATER_HEATER_MODE_OFF) {
+            const bool req_on = id(econet_water_heater).is_on();
+            const auto req_mode = id(econet_water_heater).get_mode();
+            const auto climate_mode = id(econet_climate).mode;
+
+            // Turn off: was on, now requested off.
+            if (!req_on && climate_mode != climate::CLIMATE_MODE_OFF) {
+              return climate::CLIMATE_MODE_OFF;
+            }
+            // Turn on via action: was off, now requested on.
+            if (req_on && climate_mode == climate::CLIMATE_MODE_OFF) {
+              return climate::CLIMATE_MODE_HEAT;
+            }
+            // Mode selected from UI while off: implicit turn on.
+            if (!req_on &&
+                req_mode != water_heater::WATER_HEATER_MODE_OFF &&
+                climate_mode == climate::CLIMATE_MODE_OFF) {
+              return climate::CLIMATE_MODE_HEAT;
+            }
+            if (req_mode == water_heater::WATER_HEATER_MODE_OFF) {
               return climate::CLIMATE_MODE_OFF;
             }
             return climate::CLIMATE_MODE_HEAT;
           custom_preset: !lambda |-
-            auto op_mode = id(econet_water_heater).get_mode();
-            if (op_mode == water_heater::WATER_HEATER_MODE_ECO) {
-              return {"${water_heater_eco_preset}"};
-            }
-            if (op_mode == water_heater::WATER_HEATER_MODE_PERFORMANCE) {
-              return {"Performance"};
-            }
-            if (op_mode == water_heater::WATER_HEATER_MODE_HEAT_PUMP) {
-              return {"Heat Pump"};
-            }
-            if (op_mode == water_heater::WATER_HEATER_MODE_HIGH_DEMAND) {
-              return {"High Demand"};
-            }
-            if (op_mode == water_heater::WATER_HEATER_MODE_ELECTRIC) {
-              return {"Electric"};
-            }
-            if (op_mode == water_heater::WATER_HEATER_MODE_OFF) {
+            const bool req_on = id(econet_water_heater).is_on();
+            const auto req_mode = id(econet_water_heater).get_mode();
+            const auto climate_mode = id(econet_climate).mode;
+
+            // Turn off: save current preset before switching off.
+            if (!req_on && climate_mode != climate::CLIMATE_MODE_OFF) {
+              if (id(econet_climate).has_custom_preset()) {
+                const auto current = id(econet_climate).get_custom_preset();
+                if (current != "${water_heater_off_preset}") {
+                  id(wh_last_active_preset) = current;
+                }
+              }
               return {"${water_heater_off_preset}"};
             }
-            return {};
+
+            // Turn on via action: mode_ is corrupted to OFF by the loop,
+            // so restore the last saved preset.
+            if (climate_mode == climate::CLIMATE_MODE_OFF &&
+                req_mode == water_heater::WATER_HEATER_MODE_OFF) {
+              return {id(wh_last_active_preset)};
+            }
+
+            // Mode change (while on, or selected from UI while off):
+            // map mode to preset, save it, and apply.
+            std::string preset;
+            if (req_mode == water_heater::WATER_HEATER_MODE_ECO) {
+              preset = "${water_heater_eco_preset}";
+            } else if (req_mode == water_heater::WATER_HEATER_MODE_PERFORMANCE) {
+              preset = "Performance";
+            } else if (req_mode == water_heater::WATER_HEATER_MODE_HEAT_PUMP) {
+              preset = "Heat Pump";
+            } else if (req_mode == water_heater::WATER_HEATER_MODE_HIGH_DEMAND) {
+              preset = "High Demand";
+            } else if (req_mode == water_heater::WATER_HEATER_MODE_ELECTRIC) {
+              preset = "Electric";
+            } else if (req_mode == water_heater::WATER_HEATER_MODE_GAS) {
+              preset = "${water_heater_default_mode_preset}";
+            } else {
+              preset = "${water_heater_off_preset}";
+            }
+
+            if (preset != "${water_heater_off_preset}") {
+              id(wh_last_active_preset) = preset;
+            }
+            return {preset};
+      - lambda: |-
+          ${water_heater_set_away_code}


### PR DESCRIPTION
This allows Home Assistant calling: water_heater.turn_on, water_heater.turn_off, and water_heater.set_away_mode (once https://github.com/home-assistant/core/pull/167951 is released). A global is used so than turn_on can restore to the previous preset.