### PR TITLE
Optimize logging strategy and increase default level to DEBUG

### DIFF
--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -156,7 +156,7 @@ void EconetClimate::setup() {
     this->parent_->register_listener(
         this->follow_schedule_id_, this->request_mod_, this->request_once_,
         [this](const EconetDatapoint &datapoint) {
-          ESP_LOGI(TAG, "MCU reported climate sensor %s is: %s", this->follow_schedule_id_,
+          ESP_LOGV(TAG, "MCU reported climate sensor %s is: %s", this->follow_schedule_id_,
                    datapoint.value_string.c_str());
           this->follow_schedule_ = datapoint.value_enum > 0;
           if (this->follow_schedule_.value()) {

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -166,12 +166,12 @@ void Econet::parse_message_(bool is_tx) {
   uint8_t command = b[COMMAND_POS];
   const uint8_t *pdata = b + MSG_HEADER_SIZE;
 
-  ESP_LOGI(TAG, "%s %s", is_tx ? ">>>" : "<<<",
+  ESP_LOGV(TAG, "%s %s", is_tx ? ">>>" : "<<<",
            format_hex_pretty(b, MSG_HEADER_SIZE + data_len + MSG_CRC_SIZE).c_str());
-  ESP_LOGI(TAG, "  Dst Adr : 0x%x", dst_adr);
-  ESP_LOGI(TAG, "  Src Adr : 0x%x", src_adr);
-  ESP_LOGI(TAG, "  Command : %d", command);
-  ESP_LOGI(TAG, "  Data    : %s", format_hex_pretty(pdata, data_len).c_str());
+  ESP_LOGV(TAG, "  Dst Adr : 0x%x", dst_adr);
+  ESP_LOGV(TAG, "  Src Adr : 0x%x", src_adr);
+  ESP_LOGV(TAG, "  Command : %d", command);
+  ESP_LOGV(TAG, "  Data    : %s", format_hex_pretty(pdata, data_len).c_str());
 
   uint16_t crc = (b[MSG_HEADER_SIZE + data_len]) + (b[MSG_HEADER_SIZE + data_len + 1] << 8);
   uint16_t crc_check = crc16(b, MSG_HEADER_SIZE + data_len, 0);
@@ -197,15 +197,15 @@ void Econet::parse_message_(bool is_tx) {
     uint8_t type = pdata[0] & 0x7F;
     uint8_t prop_type = pdata[1];
 
-    ESP_LOGI(TAG, "  Type    : %hhu", type);
-    ESP_LOGI(TAG, "  PropType: %hhu", prop_type);
+    ESP_LOGV(TAG, "  Type    : %hhu", type);
+    ESP_LOGV(TAG, "  PropType: %hhu", prop_type);
 
     if (type != 1 && type != 2) {
-      ESP_LOGI(TAG, "  Don't Currently Support This Class Type %hhu", type);
+      ESP_LOGD(TAG, "  Don't Currently Support This Class Type %hhu", type);
       return;
     }
     if (prop_type != 1) {
-      ESP_LOGI(TAG, "  Don't Currently Support This Property Type %hhu", prop_type);
+      ESP_LOGD(TAG, "  Don't Currently Support This Property Type %hhu", prop_type);
       return;
     }
 
@@ -218,7 +218,7 @@ void Econet::parse_message_(bool is_tx) {
     }
     extract_obj_names(pdata, data_len, &obj_names);
     for (auto &obj_name : obj_names) {
-      ESP_LOGI(TAG, "  %s", obj_name.c_str());
+      ESP_LOGV(TAG, "  %s", obj_name.c_str());
     }
     if (!obj_names.empty()) {
       this->read_req_.dst_adr = dst_adr;
@@ -275,7 +275,7 @@ void Econet::parse_message_(bool is_tx) {
     }
   } else if (command == WRITE_COMMAND) {
     uint8_t type = pdata[0];
-    ESP_LOGI(TAG, "  ClssType: %d", type);
+    ESP_LOGV(TAG, "  ClssType: %d", type);
     if (type == 1 && pdata[1] == 1 && data_len >= WRITE_DATA_POS) {
       std::string item_name((const char *) pdata + OBJ_NAME_POS, OBJ_NAME_SIZE);
       switch (EconetDatapointType(pdata[2])) {
@@ -283,13 +283,13 @@ void Econet::parse_message_(bool is_tx) {
         case EconetDatapointType::ENUM_TEXT:
           if (data_len == WRITE_DATA_POS + FLOAT_SIZE) {
             float item_value = bytes_to_float(pdata + WRITE_DATA_POS);
-            ESP_LOGI(TAG, "  %s: %f", item_name.c_str(), item_value);
+            ESP_LOGV(TAG, "  %s: %f", item_name.c_str(), item_value);
           } else {
             ESP_LOGW(TAG, "  %s: Unexpected Write Data Length", item_name.c_str());
           }
           break;
         case EconetDatapointType::RAW:
-          ESP_LOGI(TAG, "  %s: %s", item_name.c_str(),
+          ESP_LOGV(TAG, "  %s: %s", item_name.c_str(),
                    format_hex_pretty(pdata + WRITE_DATA_POS, data_len - WRITE_DATA_POS).c_str());
           break;
         case EconetDatapointType::TEXT:
@@ -301,7 +301,7 @@ void Econet::parse_message_(bool is_tx) {
           break;
       }
     } else if (type == 7) {
-      ESP_LOGI(TAG, "  DateTime: %04d/%02d/%02d %02d:%02d:%02d.%02d\n", pdata[9] | pdata[8] << 8, pdata[7], pdata[6],
+      ESP_LOGV(TAG, "  DateTime: %04d/%02d/%02d %02d:%02d:%02d.%02d\n", pdata[9] | pdata[8] << 8, pdata[7], pdata[6],
                pdata[5], pdata[4], pdata[3], pdata[2]);
     } else if (type == 9) {
       if (this->dst_adr_ != src_adr) {
@@ -329,7 +329,7 @@ void Econet::handle_response_(const EconetDatapointID &datapoint_id, const uint8
         return;
       }
       float item_value = bytes_to_float(p);
-      ESP_LOGI(TAG, "  %s : %f", datapoint_id.name.c_str(), item_value);
+      ESP_LOGV(TAG, "  %s : %f", datapoint_id.name.c_str(), item_value);
       this->send_datapoint_(
           datapoint_id,
           EconetDatapoint{.value_raw = {}, .value_string = "", .value_float = item_value, .type = item_type});
@@ -339,7 +339,7 @@ void Econet::handle_response_(const EconetDatapointID &datapoint_id, const uint8
       p += 3;
       len -= 3;
       std::string s = trim_trailing_whitespace((const char *) p, len);
-      ESP_LOGI(TAG, "  %s : (%s)", datapoint_id.name.c_str(), s.c_str());
+      ESP_LOGV(TAG, "  %s : (%s)", datapoint_id.name.c_str(), s.c_str());
       this->send_datapoint_(datapoint_id,
                             EconetDatapoint{.value_raw = {}, .value_string = s, .value_float = 0, .type = item_type});
       break;
@@ -358,7 +358,7 @@ void Econet::handle_response_(const EconetDatapointID &datapoint_id, const uint8
         return;
       }
       std::string s = trim_trailing_whitespace((const char *) p + 2, item_text_len);
-      ESP_LOGI(TAG, "  %s : %d (%s)", datapoint_id.name.c_str(), item_value, s.c_str());
+      ESP_LOGV(TAG, "  %s : %d (%s)", datapoint_id.name.c_str(), item_value, s.c_str());
       this->send_datapoint_(
           datapoint_id,
           EconetDatapoint{.value_raw = {}, .value_string = s, .value_enum = item_value, .type = item_type});
@@ -424,7 +424,7 @@ void Econet::loop() {
   int bytes_available = this->available();
   if (bytes_available > 0) {
     this->last_read_data_ = now;
-    ESP_LOGI(TAG, "Read %d. ms=%" PRIu32, bytes_available, now);
+    ESP_LOGV(TAG, "Read %d. ms=%" PRIu32, bytes_available, now);
     this->read_buffer_(bytes_available);
     return;
   }

--- a/components/econet/text_sensor/econet_text_sensor.cpp
+++ b/components/econet/text_sensor/econet_text_sensor.cpp
@@ -10,7 +10,7 @@ void EconetTextSensor::setup() {
   this->parent_->register_listener(
       this->sensor_id_, this->request_mod_, this->request_once_,
       [this](const EconetDatapoint &datapoint) {
-        ESP_LOGD(TAG, "MCU reported text sensor %s is: %s", this->sensor_id_, datapoint.value_string.c_str());
+        ESP_LOGV(TAG, "MCU reported text sensor %s is: %s", this->sensor_id_, datapoint.value_string.c_str());
         this->publish_state(datapoint.value_string);
       },
       false, this->src_adr_);

--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -7,7 +7,7 @@ substitutions:
   rx_pin: GPIO22
   github_ref: main
   external_components_source: github://esphome-econet/esphome-econet@${github_ref}
-  logger_level: WARN
+  logger_level: DEBUG
   econet_update_interval: 30s
   econet_alarm_update_interval: 30s
   econet_alarm_history_update_interval: 60s


### PR DESCRIPTION
This PR updates the logging configuration for the econet component to leverage the performance improvements introduced in ESPHome 2026.4.0 (https://esphome.io/changelog/2026.4.0/#client-side-state-logging). 

Previously, we restricted the log level to WARN to prevent the significant CPU overhead and potential event loop instability caused by formatting and transmitting large log strings over UART. With the new client-side state logging, state changes at the DEBUG level are now transmitted as compact binary data and formatted by the client, resulting in up to a 46x speed improvement in the sensor publish path.

In conjunction with commit 1f4b7d9, which moved high-volume protocol traces (hex dumps and raw message parsing) to the VERBOSE level, we can now safely set the log level to DEBUG. This provides better visibility into ESPHome logs without the performance penalties previously associated with higher log levels.
