### PR TITLE
Disable by default the vacation entity

### DIFF
--- a/econet_electric_tank_water_heater.yaml
+++ b/econet_electric_tank_water_heater.yaml
@@ -109,8 +109,7 @@ select:
   - platform: "econet"
     name: "Vacation"
     id: vaca_net
-    # TODO: Uncomment once https://github.com/home-assistant/core/pull/167951 is released
-    # disabled_by_default: true
+    disabled_by_default: true
     enum_datapoint: VACA_NET
     options:
       0: "Off"


### PR DESCRIPTION
With https://github.com/home-assistant/core/pull/167951 which will be released in Home Assistant 2026.5.0 the water heater entity will support away mode so there is no need for the vacation entity. It's now disabled by default. Existing installations won't be affected so this isn't a breaking change. Existing users, if they want, can migrate any of their automations to using the away mode in the water heater entity and disable the vacation entity.

This should be merged after Home Assistant 2026.5.0 is released.