### PR TITLE
Add additional HVAC electrical telemetry sensors

### DIFF
--- a/econet_hvac_air_handler.yaml
+++ b/econet_hvac_air_handler.yaml
@@ -28,6 +28,16 @@ sensor:
     entity_category: "diagnostic"
     filters:
       - delta: 0.9
+  - platform: econet
+    name: "Air Handler Blower Power"
+    id: air_handler_blower_power
+    sensor_datapoint: ECM_WATT
+    request_mod: none
+    unit_of_measurement: "W"
+    accuracy_decimals: 0
+    device_class: "power"
+    state_class: "measurement"
+    entity_category: "diagnostic"
 
 binary_sensor:
   - platform: econet

--- a/econet_hvac_odu.yaml
+++ b/econet_hvac_odu.yaml
@@ -289,6 +289,46 @@ sensor:
     unit_of_measurement: "kWh"
     accuracy_decimals: 1
   - platform: econet
+    name: "ODU AC Input Voltage"
+    id: odu_ac_input_voltage
+    sensor_datapoint: ISACINPV
+    request_mod: none
+    unit_of_measurement: "V"
+    accuracy_decimals: 1
+    device_class: "voltage"
+    state_class: "measurement"
+    entity_category: "diagnostic"
+  - platform: econet
+    name: "ODU AC Input Current"
+    id: odu_ac_input_current
+    sensor_datapoint: ISACINPC
+    request_mod: none
+    unit_of_measurement: "A"
+    accuracy_decimals: 1
+    device_class: "current"
+    state_class: "measurement"
+    entity_category: "diagnostic"
+  - platform: econet
+    name: "ODU Compressor Current"
+    id: odu_compressor_current
+    sensor_datapoint: IS_COMPC
+    request_mod: none
+    unit_of_measurement: "A"
+    accuracy_decimals: 1
+    device_class: "current"
+    state_class: "measurement"
+    entity_category: "diagnostic"
+  - platform: econet
+    name: "ODU Reported Power"
+    id: odu_reported_power
+    sensor_datapoint: ODU_POWR
+    request_mod: none
+    unit_of_measurement: "W"
+    accuracy_decimals: 0
+    device_class: "power"
+    state_class: "measurement"
+    entity_category: "diagnostic"
+  - platform: econet
     name: "ODU Defrost Sensor"
     id: odu_defrost_sensor
     sensor_datapoint: ODU_DEFR


### PR DESCRIPTION
## Summary

This PR adds several additional electrical telemetry sensors that are already available from EcoNet but are not currently exposed by the example HVAC packages.

### Outdoor Unit

- AC Input Voltage (`ISACINPV`)
- AC Input Current (`ISACINPC`)
- Compressor Current (`IS_COMPC`)
- Reported Power (`ODU_POWR`)

### Air Handler

- Blower Power (`ECM_WATT`)

## Why

These datapoints are already available through the EcoNet integration and provide useful diagnostics without requiring external power monitoring hardware.

They can be used to:

- Monitor compressor current
- Monitor line voltage
- Track outdoor unit power
- Monitor blower power
- Create automations
- Improve troubleshooting

## Testing

Verified on a Rheem EcoNet inverter HVAC system.

Observed values matched expected operation:

- AC Input Voltage ≈242–247 V
- AC Input Current varied appropriately with compressor load
- Blower power tracked ECM blower operation
- ODU reported power matched expected compressor operation