### PR TITLE
Fix request_once being ignored for addressed request_mods

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -498,6 +498,26 @@ void Econet::write_value_(const std::string &object, EconetDatapointType type, f
   this->transmit_message_(WRITE_COMMAND, data.data(), data.size(), address);
 }
 
+// A datapoint registered without an explicit src_address (address 0) applies to every device,
+// mirroring how send_datapoint_() matches listeners. Lookups pass a resolved destination
+// address, so a stored address of 0 is treated as a wildcard.
+static bool matches_datapoint_id(const std::vector<EconetDatapointID> &ids, const std::string &name, uint32_t address) {
+  for (const auto &id : ids) {
+    if (id.name == name && (id.address == 0 || id.address == address)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool Econet::is_request_once_(const std::string &name, uint32_t address) const {
+  return matches_datapoint_id(this->request_once_datapoint_ids_, name, address);
+}
+
+bool Econet::is_raw_datapoint_(const std::string &name, uint32_t address) const {
+  return matches_datapoint_id(this->raw_datapoint_ids_, name, address);
+}
+
 void Econet::request_strings_() {
   StaticVector<const std::string *, MAX_OBJECTS_PER_REQUEST> temp_objects;
   uint32_t dst_adr = this->dst_adr_;
@@ -511,8 +531,7 @@ void Econet::request_strings_() {
 
     // Check if we should request this service item
     EconetDatapointID entry_id{.name = entry.name, .address = dst_adr};
-    bool request_once = std::find(this->request_once_datapoint_ids_.begin(), this->request_once_datapoint_ids_.end(),
-                                  entry_id) != this->request_once_datapoint_ids_.end();
+    bool request_once = this->is_request_once_(entry.name, dst_adr);
     auto cached_it = std::find_if(this->datapoints_.begin(), this->datapoints_.end(),
                                   [&](const DatapointEntry &e) { return e.id == entry_id; });
     bool exists = cached_it != this->datapoints_.end();
@@ -532,6 +551,15 @@ void Econet::request_strings_() {
           this->request_mod_update_interval_millis_[request_mod]) {
         const auto &datapoint_ids = this->request_datapoint_ids_[request_mod];
 
+        // Resolve the destination for this request_mod up front. An unset (0) request_mod
+        // address means "use the component's dst_address", which is the same fallback
+        // transmit_message_() applies. Resolving it here keeps the request_once and cache
+        // lookups below keyed on the address the response will actually come from.
+        dst_adr = this->request_mod_addresses_[request_mod];
+        if (dst_adr == 0) {
+          dst_adr = this->dst_adr_;
+        }
+
         for (const auto &id : datapoint_ids) {
           if (temp_objects.size() >= MAX_OBJECTS_PER_REQUEST) {
             ESP_LOGW(TAG, "Too many objects for request_mod %d. Truncating to %d", request_mod,
@@ -539,11 +567,7 @@ void Econet::request_strings_() {
             break;
           }
 
-          dst_adr = this->request_mod_addresses_[request_mod];
-
-          bool request_once =
-              std::find(this->request_once_datapoint_ids_.begin(), this->request_once_datapoint_ids_.end(),
-                        EconetDatapointID{.name = id, .address = dst_adr}) != this->request_once_datapoint_ids_.end();
+          bool request_once = this->is_request_once_(id, dst_adr);
           bool exists = std::find_if(this->datapoints_.begin(), this->datapoints_.end(), [&](const DatapointEntry &e) {
                           return e.id == EconetDatapointID{.name = id, .address = dst_adr};
                         }) != this->datapoints_.end();
@@ -571,9 +595,7 @@ void Econet::request_strings_() {
   StaticVector<uint8_t, MAX_MESSAGE_SIZE> data;
 
   // Read Class
-  bool is_raw =
-      std::find(this->raw_datapoint_ids_.begin(), this->raw_datapoint_ids_.end(),
-                EconetDatapointID{.name = *temp_objects[0], .address = dst_adr}) != this->raw_datapoint_ids_.end();
+  bool is_raw = this->is_raw_datapoint_(*temp_objects[0], dst_adr);
   if (temp_objects.size() == 1 && is_raw) {
     data.push_back(1);
   } else {

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -151,6 +151,8 @@ class Econet : public Component, public uart::UARTDevice {
 
   void transmit_message_(uint8_t command, const uint8_t *data, size_t len, uint32_t dst_adr = 0, uint32_t src_adr = 0);
   void request_strings_();
+  bool is_request_once_(const std::string &name, uint32_t address) const;
+  bool is_raw_datapoint_(const std::string &name, uint32_t address) const;
   void write_value_(const std::string &object, EconetDatapointType type, float value, uint32_t address = 0);
 
   void update_intervals_() {


### PR DESCRIPTION
request_strings_() looked up request_once under {name, request_mod_addresses_[mod]}
while register_listener() stores it under the entity src_address. The two
disagree in both directions:

- ODU_SIZE / ODU_TYPE (econet_hvac_odu.yaml) set request_mod 7, whose address is
  1024, but no src_address, so they are stored under 0.
- SW_VERSN on HVAC configs sets src_address 0x380, but request_mod 4 has no
  configured address, so the lookup uses 0.

Both were re-requested on every cycle instead of once.

Resolve an unset request_mod address to dst_address, the same fallback
transmit_message_() already applies, and treat a stored address of 0 as a
wildcard, mirroring how send_datapoint_() matches listeners. The same wildcard
applies to raw datapoint lookups.