### PR TITLE
Avoid a reference into datapoints_ that send_datapoint_ can invalidate

### DIFF
--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -520,7 +520,10 @@ void Econet::request_strings_() {
     if (!(request_once && exists)) {
       temp_objects.push_back(&entry.name);
     } else {
-      this->send_datapoint_(entry_id, cached_it->data);
+      // Copy before publishing: send_datapoint_() can push_back into datapoints_, which would
+      // reallocate and leave a reference into that vector dangling for the rest of the call.
+      EconetDatapoint cached = cached_it->data;
+      this->send_datapoint_(entry_id, cached);
     }
   } else {
     // Impose a longer delay restriction for general periodically requested messages


### PR DESCRIPTION
request_strings_() passed cached_it->data, a reference into datapoints_, to
send_datapoint_(), which can push_back into that same vector. A reallocation
would leave the reference dangling for the rest of the call, including the
listener callbacks. This is safe today only because specific and wildcard
entries are always inserted as a pair, so the lookup can never miss and push -
an invariant nothing enforces. Copy into a local first.