### PR TITLE
Use const char* for the text sensor datapoint id

### DIFF
--- a/components/econet/text_sensor/econet_text_sensor.cpp
+++ b/components/econet/text_sensor/econet_text_sensor.cpp
@@ -10,7 +10,7 @@ void EconetTextSensor::setup() {
   this->parent_->register_listener(
       this->sensor_id_, this->request_mod_, this->request_once_,
       [this](const EconetDatapoint &datapoint) {
-        ESP_LOGV(TAG, "MCU reported text sensor %s is: %s", this->sensor_id_.c_str(), datapoint.value_string.c_str());
+        ESP_LOGV(TAG, "MCU reported text sensor %s is: %s", this->sensor_id_, datapoint.value_string.c_str());
         this->publish_state(datapoint.value_string);
       },
       false, this->src_adr_);
@@ -18,7 +18,7 @@ void EconetTextSensor::setup() {
 
 void EconetTextSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "Econet Text Sensor:");
-  ESP_LOGCONFIG(TAG, "  Text Sensor has datapoint ID %s", this->sensor_id_.c_str());
+  ESP_LOGCONFIG(TAG, "  Text Sensor has datapoint ID %s", this->sensor_id_);
 }
 
 }  // namespace econet

--- a/components/econet/text_sensor/econet_text_sensor.h
+++ b/components/econet/text_sensor/econet_text_sensor.h
@@ -3,7 +3,6 @@
 #include "esphome/core/component.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "../econet.h"
-#include <string>
 
 namespace esphome {
 namespace econet {
@@ -12,10 +11,10 @@ class EconetTextSensor : public text_sensor::TextSensor, public Component, publi
  public:
   void setup() override;
   void dump_config() override;
-  void set_sensor_id(const std::string &sensor_id) { this->sensor_id_ = sensor_id; }
+  void set_sensor_id(const char *sensor_id) { this->sensor_id_ = sensor_id; }
 
  protected:
-  std::string sensor_id_;
+  const char *sensor_id_{nullptr};
 };
 
 }  // namespace econet


### PR DESCRIPTION
PR #571 converted every platform id member to const char* to save heap, and
updated econet_text_sensor.cpp to drop the .c_str() calls, but never converted
the header. That left sensor_id_ a std::string being passed straight into %s
formats - undefined behaviour, since std::string is not trivially copyable and
dump_config() runs on every boot at the default log level.

PR #644 silenced the resulting warning by restoring the .c_str() calls. This
finishes the original conversion instead, bringing text_sensor in line with the
other six platforms.