### PR TITLE
Guard the climate no-schedule fan mode datapoint before writing

### DIFF
--- a/components/econet/climate/econet_climate.cpp
+++ b/components/econet/climate/econet_climate.cpp
@@ -218,8 +218,10 @@ void EconetClimate::control(const climate::ClimateCall &call) {
       if (this->follow_schedule_.has_value()) {
         if (this->follow_schedule_.value()) {
           this->parent_->set_enum_datapoint_value(this->custom_fan_mode_id_, it->id, this->src_adr_);
-        } else {
+        } else if (this->custom_fan_mode_no_schedule_id_ && *this->custom_fan_mode_no_schedule_id_) {
           this->parent_->set_enum_datapoint_value(this->custom_fan_mode_no_schedule_id_, it->id, this->src_adr_);
+        } else {
+          ESP_LOGW(TAG, "Not following the schedule but custom_fan_mode_no_schedule_datapoint is not configured");
         }
       }
     }


### PR DESCRIPTION
When follow_schedule is false, control() wrote to
custom_fan_mode_no_schedule_id_ without checking it was configured. Its schema
default is an empty string, so an unconfigured one produced a write command with
an all-zero object name.