### PR TITLE
Fix the number write path reporting success for writes it never sent

### DIFF
--- a/components/econet/number/econet_number.cpp
+++ b/components/econet/number/econet_number.cpp
@@ -1,6 +1,8 @@
 #include "econet_number.h"
 #include "esphome/core/log.h"
 
+#include <cmath>
+
 namespace esphome {
 namespace econet {
 
@@ -27,7 +29,20 @@ void EconetNumber::control(float value) {
   if (this->type_ == EconetDatapointType::FLOAT) {
     this->parent_->set_float_datapoint_value(this->number_id_, value, this->src_adr_);
   } else if (this->type_ == EconetDatapointType::ENUM_TEXT) {
-    this->parent_->set_enum_datapoint_value(this->number_id_, value, this->src_adr_);
+    // The datapoint carries a uint8_t. Round rather than truncate, and clamp: min_value or
+    // max_value may fall outside 0-255, and an out-of-range float-to-integer conversion is
+    // undefined behavior.
+    float rounded = roundf(value);
+    if (rounded < 0.0f || rounded > 255.0f) {
+      ESP_LOGW(TAG, "Value %f for number %s is out of range for an enum datapoint", value, this->number_id_);
+      return;
+    }
+    this->parent_->set_enum_datapoint_value(this->number_id_, static_cast<uint8_t>(rounded), this->src_adr_);
+  } else {
+    // No write was sent, so don't publish the new value: doing so would report success in
+    // Home Assistant for a change that never reached the unit.
+    ESP_LOGW(TAG, "Cannot write number %s: datapoint type is not writable", this->number_id_);
+    return;
   }
   this->publish_state(value);
 }


### PR DESCRIPTION
For TEXT, RAW and UNSUPPORTED datapoint types control() sent no write but still
called publish_state(value), so Home Assistant showed the new value for a change
that never reached the unit. Log and return instead.

Also round rather than truncate the ENUM_TEXT conversion, and range-check it.
NumberCall::perform() clamps to min_value/max_value but does not round to step,
so control() receives arbitrary in-range floats; RELHOFFS is configured
min=-9.5 max=9.5 step=0.5, and converting a negative or out-of-range float to
uint8_t is undefined behaviour.