### PR TITLE
Actually validate that mapping values are unique

### DIFF
--- a/components/econet/__init__.py
+++ b/components/econet/__init__.py
@@ -52,6 +52,29 @@ def assign_declare_id(value):
     return value
 
 
+def unique_value_map(value_validator):
+    """Build a validator for a {uint8: value} mapping whose values must be unique.
+
+    Duplicate values make one of the keys unreachable: the C++ side resolves a value back
+    to the first key that maps to it.
+    """
+
+    def validator(value):
+        cv.check_not_templatable(value)
+        value = cv.Schema({cv.uint8_t: value_validator})(value)
+        seen = {}
+        for key, mapped in value.items():
+            if mapped in seen:
+                raise cv.Invalid(
+                    f"Mapping values must be unique, but {mapped!r} is used for both "
+                    f"{seen[mapped]} and {key}."
+                )
+            seen[mapped] = key
+        return value
+
+    return validator
+
+
 def validate_request_mod_range(value):
     return cv.int_range(min=0, max=15)(value)
 

--- a/components/econet/climate/__init__.py
+++ b/components/econet/climate/__init__.py
@@ -11,6 +11,7 @@ from .. import (
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
+    unique_value_map,
 )
 
 DEPENDENCIES = ["econet"]
@@ -33,26 +34,9 @@ EconetClimate = econet_ns.class_(
 )
 
 
-def ensure_climate_mode_map(value):
-    cv.check_not_templatable(value)
-    options_map_schema = cv.Schema({cv.uint8_t: climate.validate_climate_mode})
-    value = options_map_schema(value)
-    all_values = list(value.keys())
-    unique_values = set(value.keys())
-    if len(all_values) != len(unique_values):
-        raise cv.Invalid("Mapping values must be unique.")
-    return value
+ensure_climate_mode_map = unique_value_map(climate.validate_climate_mode)
 
-
-def ensure_option_map(value):
-    cv.check_not_templatable(value)
-    options_map_schema = cv.Schema({cv.uint8_t: cv.string_strict})
-    value = options_map_schema(value)
-    all_values = list(value.keys())
-    unique_values = set(value.keys())
-    if len(all_values) != len(unique_values):
-        raise cv.Invalid("Mapping values must be unique.")
-    return value
+ensure_option_map = unique_value_map(cv.string_strict)
 
 
 CONFIG_SCHEMA = cv.All(

--- a/components/econet/select/__init__.py
+++ b/components/econet/select/__init__.py
@@ -11,6 +11,7 @@ from .. import (
     ECONET_CLIENT_SCHEMA,
     EconetClient,
     econet_ns,
+    unique_value_map,
 )
 
 DEPENDENCIES = ["econet"]
@@ -20,15 +21,7 @@ EconetSelect = econet_ns.class_(
 )
 
 
-def ensure_option_map(value):
-    cv.check_not_templatable(value)
-    options_map_schema = cv.Schema({cv.uint8_t: cv.string_strict})
-    value = options_map_schema(value)
-    all_values = list(value.keys())
-    unique_values = set(value.keys())
-    if len(all_values) != len(unique_values):
-        raise cv.Invalid("Mapping values must be unique.")
-    return value
+ensure_option_map = unique_value_map(cv.string_strict)
 
 
 CONFIG_SCHEMA = (


### PR DESCRIPTION
ensure_option_map and ensure_climate_mode_map compared list(value.keys()) with
set(value.keys()) after the schema had already produced a dict, so the check
could never fire despite an error message about values. Duplicate labels make
one key unreachable: the C++ side resolves a value back to the first key that
maps to it.

Check the values instead, and name both colliding keys in the message. The three
copies of the check are consolidated into one helper - three duplicates of a
vacuous check is what let it go unnoticed.