### PR TITLE
Reject a single-point target temperature combined with a two-point one

### DIFF
--- a/components/econet/climate/__init__.py
+++ b/components/econet/climate/__init__.py
@@ -55,6 +55,24 @@ def ensure_option_map(value):
     return value
 
 
+def validate_target_temperature_datapoints(config):
+    """Reject a single-point target temperature combined with a two-point one.
+
+    Climate stores target_temperature in a union with target_temperature_low/high, so
+    listeners for both would write over each other's value.
+    """
+    if config[CONF_TARGET_TEMPERATURE_DATAPOINT] and (
+        config[CONF_TARGET_TEMPERATURE_LOW_DATAPOINT]
+        or config[CONF_TARGET_TEMPERATURE_HIGH_DATAPOINT]
+    ):
+        raise cv.Invalid(
+            f"{CONF_TARGET_TEMPERATURE_DATAPOINT} cannot be combined with "
+            f"{CONF_TARGET_TEMPERATURE_LOW_DATAPOINT} or "
+            f"{CONF_TARGET_TEMPERATURE_HIGH_DATAPOINT}: they share the same storage."
+        )
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     climate.climate_schema(EconetClimate)
     .extend(
@@ -80,7 +98,8 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(ECONET_CLIENT_SCHEMA)
+    .extend(ECONET_CLIENT_SCHEMA),
+    validate_target_temperature_datapoints,
 )
 
 


### PR DESCRIPTION
Climate stores target_temperature in a union with target_temperature_low and
target_temperature_high, so listeners registered for both write over each
other. Nothing prevented configuring both; it is latent only because no shipped
config does.