### PR TITLE
Fix format warning, dead code and uninitialized members

### DIFF
--- a/components/econet/automation.cpp
+++ b/components/econet/automation.cpp
@@ -1,8 +1,4 @@
-#include "esphome/core/log.h"
-
 #include "automation.h"
-
-static const char *const TAG = "econet.automation";
 
 namespace esphome {
 namespace econet {

--- a/components/econet/econet.cpp
+++ b/components/econet/econet.cpp
@@ -263,7 +263,7 @@ void Econet::parse_message_(bool is_tx) {
           item_num++;
         }
         if (item_num != this->read_req_.obj_names.size()) {
-          ESP_LOGE(TAG, "We requested %d objects but we received %d. Ignoring response.",
+          ESP_LOGE(TAG, "We requested %zu objects but we received %d. Ignoring response.",
                    this->read_req_.obj_names.size(), item_num);
         } else {
           // 2nd pass to handle response

--- a/components/econet/econet.h
+++ b/components/econet/econet.h
@@ -109,6 +109,9 @@ class Econet : public Component, public uart::UARTDevice {
   }
   void init_request_mod_update_intervals(size_t size) { this->request_mod_update_interval_millis_map_.init(size); }
   void add_request_mod_update_interval(uint8_t mod, uint32_t interval) {
+    if (mod >= MAX_REQUEST_MODS) {
+      return;
+    }
     this->request_mod_update_interval_millis_map_.push_back({mod, interval});
     this->update_intervals_();
   }
@@ -223,7 +226,7 @@ class EconetClient {
   void set_src_adr(uint32_t src_adr) { this->src_adr_ = src_adr; }
 
  protected:
-  Econet *parent_;
+  Econet *parent_{nullptr};
   uint32_t src_adr_{0};
   int8_t request_mod_{0};
   bool request_once_{false};


### PR DESCRIPTION
- %d -> %zu for a size_t in the object-count mismatch log.
- Initialize EconetClient::parent_, matching its sibling members.
- Bounds-guard add_request_mod_update_interval, matching add_request_mod_address;
  update_intervals_() indexes a fixed 16-element array with it.
- Drop the unused TAG and log.h include from automation.cpp.