### PR TITLE
Give web-installed devices unique names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,8 @@ jobs:
             yq -P -i
             '
               .improv_serial = "" |
-              .improv_serial tag = "!!null"
+              .improv_serial tag = "!!null" |
+              .esphome.name_add_mac_suffix = true
             '
             build-yaml/econet-${{ matrix.appliance.shorthand }}-${{ matrix.platform }}.yaml
       - name: Force Verbose Logging

--- a/build-yaml/econet-etwh-esp32.yaml
+++ b/build-yaml/econet-etwh-esp32.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-etwh-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-etwh-esp32c3.yaml
+++ b/build-yaml/econet-etwh-esp32c3.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-etwh-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-etwh-esp32s3.yaml
+++ b/build-yaml/econet-etwh-esp32s3.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-etwh-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-etwh-esp8266.yaml
+++ b/build-yaml/econet-etwh-esp8266.yaml
@@ -13,7 +13,7 @@ packages:
     file: econet_electric_tank_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-etwh-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp32.yaml
+++ b/build-yaml/econet-hpwh-esp32.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hpwh-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp32c3.yaml
+++ b/build-yaml/econet-hpwh-esp32c3.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hpwh-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp32s3.yaml
+++ b/build-yaml/econet-hpwh-esp32s3.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hpwh-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hpwh-esp8266.yaml
+++ b/build-yaml/econet-hpwh-esp8266.yaml
@@ -13,7 +13,7 @@ packages:
     file: econet_heatpump_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hpwh-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_air_handler-esp32.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32.yaml
@@ -21,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_air_handler-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_air_handler-esp32c3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32c3.yaml
@@ -21,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_air_handler-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_air_handler-esp32s3.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp32s3.yaml
@@ -21,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_air_handler-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_air_handler-esp8266.yaml
+++ b/build-yaml/econet-hvac_air_handler-esp8266.yaml
@@ -18,7 +18,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_air_handler-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp32.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32.yaml
@@ -21,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_furnace-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp32c3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32c3.yaml
@@ -21,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_furnace-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp32s3.yaml
+++ b/build-yaml/econet-hvac_furnace-esp32s3.yaml
@@ -21,7 +21,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_furnace-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-hvac_furnace-esp8266.yaml
+++ b/build-yaml/econet-hvac_furnace-esp8266.yaml
@@ -18,7 +18,7 @@ packages:
   #   file: econet_hvac_odu.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-hvac_furnace-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp32.yaml
+++ b/build-yaml/econet-tlwh-esp32.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-tlwh-esp32.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp32c3.yaml
+++ b/build-yaml/econet-tlwh-esp32c3.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32c3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-tlwh-esp32c3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp32s3.yaml
+++ b/build-yaml/econet-tlwh-esp32s3.yaml
@@ -16,7 +16,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp32s3.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-tlwh-esp32s3.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file

--- a/build-yaml/econet-tlwh-esp8266.yaml
+++ b/build-yaml/econet-tlwh-esp8266.yaml
@@ -13,7 +13,7 @@ packages:
     file: econet_tankless_water_heater.yaml
 
 dashboard_import:
-  package_import_url: github://esphome-econet/esphome-econet/build-yaml/${name}-esp8266.yaml@${github_ref}
+  package_import_url: github://esphome-econet/esphome-econet/build-yaml/econet-tlwh-esp8266.yaml@${github_ref}
   import_full_config: false
 
 # Uncomment the below to use Wi-Fi settings from your secrets.yaml file


### PR DESCRIPTION
Fixes #662 (the naming half of it).

Firmware flashed from the [web installer](https://esphome-econet.github.io/install/) always boots with the same hardcoded name (`econet-etwh`, `econet-hpwh`, ...), so a second unit of the same appliance type collides with the first over mDNS and neither can be reliably added to Home Assistant. The reporter hit exactly this, and it kept failing even after they deleted the first device from HA.

## Changes

- **`.github/workflows/build.yml`**: set `esphome.name_add_mac_suffix` during the firmware build, alongside the existing `improv_serial` injection. Published devices now come up as e.g. `econet-etwh-a1b2c3`, so any number of units can coexist. Doing it at build time rather than in `econet_base.yaml` keeps names clean for configs users compile themselves, and avoids renaming already-deployed devices on their next OTA. On adoption, the dashboard bakes in the discovered suffixed name with `name_add_mac_suffix: false`, so users can rename from there.
- **`build-yaml/*.yaml`**: hardcode the file name in `dashboard_import.package_import_url` instead of using `${name}`. After adoption the `name` substitution holds the device's own (now suffixed) name, which would make that URL point at a file that doesn't exist. This matches ESPHome's own [project template](https://esphome.io/guides/creators/).

## Testing

Validated with ESPHome 2026.8.1 against local copies with the CI transforms applied: `econet-etwh-esp32` and `econet-hvac_air_handler-esp8266` both report `Configuration is valid!` with `name_add_mac_suffix: true`. The air handler is the longest name (23 chars + 7-char suffix); its underscore warning is pre-existing. The build workflow covers the remaining appliance/platform combinations.

Note for #662: the other half of that request (add an `api:` section) isn't needed — `econet_base.yaml` already has one. That Home Assistant message is its generic connect-failure string, and the duplicate hostname above is the actual cause.