### PR TITLE
Don't publish water heater temperatures before the MCU responds

### DIFF
--- a/econet_water_heater_base.yaml
+++ b/econet_water_heater_base.yaml
@@ -13,8 +13,24 @@ water_heater:
       min_temperature: "110 °F"
       max_temperature: "140 °F"
       target_temperature_step: 1
-    current_temperature: !lambda "return id(econet_climate).current_temperature;"
-    target_temperature: !lambda "return id(econet_climate).target_temperature;"
+    # Return {} (don't publish) while the value is unknown: NAN never compares equal to itself,
+    # so the template water heater treats it as a change on every loop iteration and republishes
+    # the state until the MCU reports a value.
+    # TODO: once https://github.com/esphome/esphome/pull/19013 is in a release, raise min_version
+    # in econet_base.yaml to it and simplify both lambdas back to a plain
+    # `return id(econet_climate).<field>;`.
+    current_temperature: !lambda |-
+      const float temp = id(econet_climate).current_temperature;
+      if (std::isnan(temp)) {
+        return {};
+      }
+      return temp;
+    target_temperature: !lambda |-
+      const float temp = id(econet_climate).target_temperature;
+      if (std::isnan(temp)) {
+        return {};
+      }
+      return temp;
     is_on: !lambda |-
       if (id(econet_climate).mode == climate::CLIMATE_MODE_OFF) {
         return false;


### PR DESCRIPTION
The template water heater decides whether to publish by comparing each lambda's result against
the stored value, and NAN never compares equal to itself. `econet_climate`'s temperatures are NAN
until the MCU answers, so every loop iteration looked like a change and republished the state -
flooding the API and the logs for the whole startup window:

```
[00:02:53.150][S][water_heater]: '' >>
[00:02:53.150][S][water_heater]:   Mode: OFF
```

Return `{}` (don't publish) while the value is unknown. The water heater then keeps its default
NAN and publishes once the MCU reports a real value.

Fixed upstream in esphome/esphome#19013 as well, but this keeps working on the releases
`min_version: 2026.4.0` already allows - every released version with `water_heater` has the bug.
A TODO on the lambdas records that both can go back to a plain
`return id(econet_climate).<field>;`, with `min_version` raised, once that fix ships.

Verified on an ESP8266 heat pump water heater: startup no longer spams, and the water heater now
publishes once per `econet_update_interval` with real values.
