### PR TITLE
Attribute releases to release App bot instead of a personal PAT

### DIFF
--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -18,6 +18,8 @@ jobs:
   update-version-strings:
     name: Update Version Strings
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Generate Release Version
         id: generate_release_version
@@ -27,9 +29,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prefix: "v"
           dry_run: true
+      # Mint an installation token for a GitHub App so the commit push and
+      # release are attributed to the app bot (e.g. `my-app[bot]`) instead of
+      # a personal account. Setup: register an App with Contents (read/write)
+      # permission, install it on this repo, then store its numeric App ID in
+      # RELEASE_APP_ID and its private key (.pem contents) in
+      # RELEASE_APP_PRIVATE_KEY. Unlike GITHUB_TOKEN, an App token still
+      # triggers the downstream `release: published` workflow
+      # (build-and-publish). For the App to push to a protected branch, also
+      # add it to the branch ruleset's bypass list.
+      - name: Mint release automation token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:
-          token: ${{ secrets.RELEASE_AUTOMATION_ACTION }}
+          token: ${{ steps.release-token.outputs.token }}
       - name: Update Project Version String
         uses: mikefarah/yq@v4
         with:
@@ -44,9 +61,16 @@ jobs:
         with:
           commit_message: "Automated project versioning update"
           push_options: '--force'
+          # Attribute the commit author to whoever dispatched the workflow
+          # (github.actor) instead of the token owner, with the bot as
+          # committer. These match the action defaults but are explicit so
+          # attribution doesn't silently regress on action upgrades.
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true
           tag: ${{ steps.generate_release_version.outputs.version_tag }}
-          token: ${{ secrets.RELEASE_AUTOMATION_ACTION }}
+          token: ${{ steps.release-token.outputs.token }}

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -33,8 +33,8 @@ jobs:
       # release are attributed to the app bot (e.g. `my-app[bot]`) instead of
       # a personal account. Setup: register an App with Contents (read/write)
       # permission, install it on this repo, then store its numeric App ID in
-      # RELEASE_APP_ID and its private key (.pem contents) in
-      # RELEASE_APP_PRIVATE_KEY. Unlike GITHUB_TOKEN, an App token still
+      # the RELEASE_APP_ID variable and its private key (.pem contents) in
+      # the RELEASE_APP_PRIVATE_KEY secret. Unlike GITHUB_TOKEN, an App token
       # triggers the downstream `release: published` workflow
       # (build-and-publish). For the App to push to a protected branch, also
       # add it to the branch ruleset's bypass list.
@@ -42,7 +42,7 @@ jobs:
         id: release-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Releases cut via Release Firmware are currently authored by barndawgie because the workflow authenticates with his personal PAT (`RELEASE_AUTOMATION_ACTION`), no matter who clicks the button.

This switches the workflow to a short-lived GitHub App installation token (`actions/create-github-app-token`), so commits push and Releases are authored by the App bot. The version-bump commit author stays the dispatcher (`github.actor`), committer `github-actions[bot]`. Unlike `GITHUB_TOKEN`, an App token still fires the downstream `release: published` build.

Proven on tronikos/esphome-econet fork:
- Test-branch run: release author `esphome-econet-release[bot]`, commit author dispatcher — green.
- Ruleset-protected `main` run: push + release green with the App as ruleset bypass actor.
- `GITHUB_TOKEN`-only variant was rejected by branch protection (`GH006`), and `GITHUB_TOKEN` cannot be a bypass actor by design — hence the App.

Required setup BEFORE merging (or the next release run fails):
1. Install the release App on this repo and add `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` secrets.
2. Migrate `main` protection to an equivalent ruleset with the App as `Integration` bypass (classic protection cannot exempt status checks).

After merge + one verified release: retire the `RELEASE_AUTOMATION_ACTION` PAT.